### PR TITLE
Secure Unifi-controller, move the config folder outside of the repo, show btrfs compression stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Configuration folder
+# Configuration folder/symlink
 /config/
+/config
 
 # Taskfile checksums
 .task/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -66,6 +66,11 @@ tasks:
       - task: docs:clean
       - cd terraform && make clean
 
+  compsize:
+    desc: Show btrfs compression stats
+    cmds:
+      - sudo compsize -x /
+
   star-github-repos:
     desc: Add star to all referenced GitHub repos
     dotenv: ['config/docker/.env']

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -68,8 +68,19 @@ tasks:
 
   compsize:
     desc: Show btrfs compression stats
+    silent: true
     cmds:
-      - sudo compsize -x /
+      - |
+        if ! command -v compsize >/dev/null 2>&1; then
+          echo "Error: compsize is not installed. Please install it first."
+          exit 1
+        fi
+        if ! findmnt -n -o FSTYPE / | grep -q "btrfs"; then
+          echo "Error: Root filesystem is not btrfs"
+          exit 1
+        fi
+        echo "Analyzing btrfs compression stats (this may take a while)..."
+        sudo compsize -x /
 
   star-github-repos:
     desc: Add star to all referenced GitHub repos

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -102,5 +102,5 @@ tasks:
   backup-config:
     desc: Compress the config directory
     cmds:
-      - tar -cjf "../infra-config-$(date +%Y-%m-%d_%H-%M-%S).tar.bz2" config
-      - ls -lh ../infra-config-*.tar.bz2
+      - cd config && tar -cjf "../infra-config-$(date +%Y-%m-%d_%H-%M-%S).tar.bz2" .
+      - ls -lh ../infra-config-*.tar.bz2 | tail -n 5

--- a/config-example/docker/myhost/.env
+++ b/config-example/docker/myhost/.env
@@ -54,8 +54,11 @@ CROWDSEC_BOUNCER_API_KEY="use-some-very-secure-value-here"
 
 # Cloud accounts
 
-UNIFI_USERNAME="bubacoder@gmail.com"
-UNIFI_PASSWORD="use-some-very-secure-value-here"
+# Use a local account that has at least read privileges. Local account can be created on the Legacy Interface.
+# To temporally switch to the old interface: Settings -> System -> Legacy Interface -> Enable
+# Then create the user on Settings -> Admins
+UNIFI_LOCAL_VIEWONLY_USERNAME="viewonly"
+UNIFI_LOCAL_VIEWONLY_PASSWORD="use-some-very-secure-value-here"
 
 CLOUDFLARE_DNS_API_TOKEN="use-some-very-secure-value-here"
 CLOUDFLARE_TUNNEL_TOKEN="use-some-very-secure-value-here"

--- a/config-example/docker/myhost/apply.sh
+++ b/config-example/docker/myhost/apply.sh
@@ -2,9 +2,19 @@
 set -e
 
 # shellcheck disable=SC2034,SC2046
-HOST_CONFIG_DIR=$(dirname $(realpath "$0"))
+HOST_CONFIG_DIR=$(dirname $(realpath -s "$0"))
+
+# If the config dir is within the infra repo
+DOCKER_STACKS_DIR=${HOST_CONFIG_DIR}/../../../docker/
+
+if [ ! -d "$DOCKER_STACKS_DIR" ]; then
+  # If the config dir is a separate repo
+  DOCKER_STACKS_DIR=${HOST_CONFIG_DIR}/../../../infra/docker/
+fi
+
 # shellcheck disable=SC1091
-source ../../../docker/common.sh
+source "${DOCKER_STACKS_DIR}/common.sh"
+
 init "myhost"
 
 set +e

--- a/docker/infra/unifi-controller.yaml
+++ b/docker/infra/unifi-controller.yaml
@@ -1,10 +1,14 @@
 # The Unifi-controller software is a powerful, enterprise wireless software engine ideal for high-density client deployments requiring low latency and high uptime performance.
 #
-# Note: this service uses an online account for logging in on the admin interface! Configure via `${UNIFI_USERNAME}` and `${UNIFI_PASSWORD}`.
-#
 # For Unifi to adopt other devices, e.g. an Access Point, it is required to change the *inform* IP address.
 # Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices.
 # To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices.
+#
+# For the Homepage widget use a local account that has read privileges.
+# Local account can be created on the Legacy Interface:
+# - To temporally switch to the old interface: Settings -> System -> Legacy Interface -> Enable
+# - Create the user on Settings -> Admins
+# - Set the `${UNIFI_LOCAL_VIEWONLY_USERNAME}` and `${UNIFI_LOCAL_VIEWONLY_PASSWORD}` variables
 #
 # 🏠 Home: https://ui.com/download/releases/network-server  
 # 📦 Image: https://hub.docker.com/r/linuxserver/unifi-controller  
@@ -49,8 +53,8 @@ services:
       homepage.description: Wireless software engine
       homepage.widget.type: unifi
       homepage.widget.url: https://unifi-controller.${MYDOMAIN}
-      homepage.widget.username: ${UNIFI_USERNAME}
-      homepage.widget.password: ${UNIFI_PASSWORD}
+      homepage.widget.username: ${UNIFI_LOCAL_VIEWONLY_USERNAME}
+      homepage.widget.password: ${UNIFI_LOCAL_VIEWONLY_PASSWORD}
       # - homepage.widget.site: Site Name # optional
 
 networks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Configuration**
  - Updated `.gitignore` to enhance configuration folder tracking.
  - Modified environment variables for UniFi controller access to use local view-only credentials.

- **Docker**
  - Improved handling of Docker stack directories in configuration scripts.
  - Added a new service command for `tales` in the configuration script.

- **Taskfile**
  - Added a new task for checking Btrfs compression statistics.
  - Enhanced backup configuration task with updated directory handling and output display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->