### PR TITLE
Revert Kasm Workspaces version, limit version range for Renovate

### DIFF
--- a/docker/tools/kasm.yaml
+++ b/docker/tools/kasm.yaml
@@ -12,13 +12,21 @@
 # - admin@kasm.local
 # - user@kasm.local
 #
+# To add a persistent profile path to a Workspace:
+# - From the administrator menu first click on Workspaces -> Workspaces and edit your desired Workspace:
+# - Set "Persistent Profile Path" to `/profiles/{image_id}/{user_id}`
+# Details: https://kasmweb.com/docs/latest/guide/persistent_data/persistent_profiles.html#adding-a-persistent-profile-to-a-workspace
+#
+# Kasm Workspaces can be configured to connect to fixed remote endpoints that are using either the Remote Desktop Protocol, VNC or SSH.  
+# Details: https://kasmweb.com/docs/latest/how_to/fixed_infrastructure.html
+#
 # https://www.kasmweb.com/  
 # https://docs.linuxserver.io/images/docker-kasm/
 ---
 name: kasm
 services:
   kasm:
-    image: lscr.io/linuxserver/kasm:1.120.20221218
+    image: lscr.io/linuxserver/kasm:1.16.1
     container_name: kasm
     restart: unless-stopped
     # kics-scan ignore-line

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,13 @@
       "allowedVersions": "<1"
     },
     {
+      "description": "Disable invalid version tags",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchPackageNames": ["lscr.io/linuxserver/kasm"],
+      "allowedVersions": "<1.120"
+    },
+
+    {
       "description": "Updates of renovatebot are too frequent - update only to major versions",
       "matchManagers": ["pre-commit"],
       "matchPackageNames": ["renovatebot/pre-commit-hooks"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added guidance for administrators on configuring persistent profiles and remote service connections in Kasm Workspaces

- **Chores**
	- Updated Kasm container image version from 1.120.20221218 to 1.16.1
	- Added version constraint rule for Kasm package in Renovate configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->