### PR TITLE
Simplify Docker reverse proxy annotations, restructure Traefik middleware to support HTTP protocol

### DIFF
--- a/docker/ai/autogenstudio.yaml
+++ b/docker/ai/autogenstudio.yaml
@@ -18,7 +18,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.autogenstudio.entrypoints: websecure
       traefik.http.routers.autogenstudio.middlewares: localaccess@file
       traefik.http.services.autogenstudio.loadbalancer.server.port: 8081
       homepage.group: AI

--- a/docker/ai/autogenstudio.yaml
+++ b/docker/ai/autogenstudio.yaml
@@ -19,7 +19,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.autogenstudio.entrypoints: websecure
-      traefik.http.routers.autogenstudio.middlewares: https-local@file
+      traefik.http.routers.autogenstudio.middlewares: localaccess@file
       traefik.http.services.autogenstudio.loadbalancer.server.port: 8081
       homepage.group: AI
       homepage.name: AutoGen Studio

--- a/docker/ai/litellm.yaml
+++ b/docker/ai/litellm.yaml
@@ -22,7 +22,6 @@ services:
       REMOTE_OLLAMA_API_BASE: http://localhost:11444
     labels:
       traefik.enable: true
-      traefik.http.routers.litellm.entrypoints: websecure
       traefik.http.routers.litellm.middlewares: localaccess@file
       traefik.http.services.litellm.loadbalancer.server.port: 4000
       homepage.group: AI

--- a/docker/ai/litellm.yaml
+++ b/docker/ai/litellm.yaml
@@ -23,7 +23,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.litellm.entrypoints: websecure
-      traefik.http.routers.litellm.middlewares: https-local@file
+      traefik.http.routers.litellm.middlewares: localaccess@file
       traefik.http.services.litellm.loadbalancer.server.port: 4000
       homepage.group: AI
       homepage.name: "LiteLLM"

--- a/docker/ai/ollama.yaml
+++ b/docker/ai/ollama.yaml
@@ -27,7 +27,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.ollama.entrypoints: websecure
-      traefik.http.routers.ollama.middlewares: https-local@file
+      traefik.http.routers.ollama.middlewares: localaccess@file
       traefik.http.services.ollama.loadbalancer.server.port: 11434
       homepage.group: AI
       homepage.name: "Ollama"

--- a/docker/ai/ollama.yaml
+++ b/docker/ai/ollama.yaml
@@ -26,7 +26,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.ollama.entrypoints: websecure
       traefik.http.routers.ollama.middlewares: localaccess@file
       traefik.http.services.ollama.loadbalancer.server.port: 11434
       homepage.group: AI

--- a/docker/ai/open-webui-pipelines.yaml
+++ b/docker/ai/open-webui-pipelines.yaml
@@ -19,7 +19,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.open-webui-pipelines.entrypoints: websecure
-      traefik.http.routers.open-webui-pipelines.middlewares: https-local@file
+      traefik.http.routers.open-webui-pipelines.middlewares: localaccess@file
       traefik.http.routers.open-webui-pipelines.rule: Host(`open-webui-pipelines.${MYDOMAIN}`)
       traefik.http.services.open-webui-pipelines.loadbalancer.server.port: 9099
       homepage.group: AI

--- a/docker/ai/open-webui-pipelines.yaml
+++ b/docker/ai/open-webui-pipelines.yaml
@@ -18,7 +18,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.open-webui-pipelines.entrypoints: websecure
       traefik.http.routers.open-webui-pipelines.middlewares: localaccess@file
       traefik.http.routers.open-webui-pipelines.rule: Host(`open-webui-pipelines.${MYDOMAIN}`)
       traefik.http.services.open-webui-pipelines.loadbalancer.server.port: 9099

--- a/docker/ai/open-webui.yaml
+++ b/docker/ai/open-webui.yaml
@@ -34,7 +34,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.open-webui.entrypoints: websecure
-      traefik.http.routers.open-webui.middlewares: https-local@file
+      traefik.http.routers.open-webui.middlewares: localaccess@file
       traefik.http.services.open-webui.loadbalancer.server.port: 8080
       homepage.group: AI
       homepage.name: "Open WebUI"

--- a/docker/ai/open-webui.yaml
+++ b/docker/ai/open-webui.yaml
@@ -33,7 +33,6 @@ services:
       - host.docker.internal:host-gateway
     labels:
       traefik.enable: true
-      traefik.http.routers.open-webui.entrypoints: websecure
       traefik.http.routers.open-webui.middlewares: localaccess@file
       traefik.http.services.open-webui.loadbalancer.server.port: 8080
       homepage.group: AI

--- a/docker/ai/qdrant.yaml
+++ b/docker/ai/qdrant.yaml
@@ -33,7 +33,6 @@ services:
       QDRANT__SERVICE__ENABLE_CORS: false # TODO how do restrict to https://qdrant.${MYDOMAIN} ?
     labels:
       traefik.enable: true
-      traefik.http.routers.qdrant.entrypoints: websecure
       traefik.http.routers.qdrant.middlewares: localaccess@file
       traefik.http.services.qdrant.loadbalancer.server.port: 6333
       homepage.group: AI

--- a/docker/ai/qdrant.yaml
+++ b/docker/ai/qdrant.yaml
@@ -34,7 +34,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.qdrant.entrypoints: websecure
-      traefik.http.routers.qdrant.middlewares: https-local@file
+      traefik.http.routers.qdrant.middlewares: localaccess@file
       traefik.http.services.qdrant.loadbalancer.server.port: 6333
       homepage.group: AI
       homepage.name: "Qdrant"

--- a/docker/ai/sillytavern.yaml
+++ b/docker/ai/sillytavern.yaml
@@ -34,7 +34,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.sillytavern.entrypoints: websecure
-      traefik.http.routers.sillytavern.middlewares: https-local@file
+      traefik.http.routers.sillytavern.middlewares: localaccess@file
       traefik.http.services.sillytavern.loadbalancer.server.port: 8000
       homepage.group: AI
       homepage.name: SillyTavern

--- a/docker/ai/sillytavern.yaml
+++ b/docker/ai/sillytavern.yaml
@@ -33,7 +33,6 @@ services:
         condition: service_completed_successfully
     labels:
       traefik.enable: true
-      traefik.http.routers.sillytavern.entrypoints: websecure
       traefik.http.routers.sillytavern.middlewares: localaccess@file
       traefik.http.services.sillytavern.loadbalancer.server.port: 8000
       homepage.group: AI

--- a/docker/arr/bazarr.yaml
+++ b/docker/arr/bazarr.yaml
@@ -22,7 +22,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.bazarr.entrypoints: websecure
-      traefik.http.routers.bazarr.middlewares: https-local@file
+      traefik.http.routers.bazarr.middlewares: localaccess@file
       traefik.http.services.bazarr.loadbalancer.server.port: 6767
       homepage.group: Arr
       homepage.name: Bazarr

--- a/docker/arr/bazarr.yaml
+++ b/docker/arr/bazarr.yaml
@@ -21,7 +21,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.bazarr.entrypoints: websecure
       traefik.http.routers.bazarr.middlewares: localaccess@file
       traefik.http.services.bazarr.loadbalancer.server.port: 6767
       homepage.group: Arr

--- a/docker/arr/flaresolverr.yaml
+++ b/docker/arr/flaresolverr.yaml
@@ -19,7 +19,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.flaresolverr.entrypoints: websecure
       traefik.http.routers.flaresolverr.middlewares: localaccess@file
       traefik.http.services.flaresolverr.loadbalancer.server.port: 8191
       homepage.group: Arr

--- a/docker/arr/flaresolverr.yaml
+++ b/docker/arr/flaresolverr.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.flaresolverr.entrypoints: websecure
-      traefik.http.routers.flaresolverr.middlewares: https-local@file
+      traefik.http.routers.flaresolverr.middlewares: localaccess@file
       traefik.http.services.flaresolverr.loadbalancer.server.port: 8191
       homepage.group: Arr
       homepage.name: Flaresolverr

--- a/docker/arr/jellyseerr.yaml
+++ b/docker/arr/jellyseerr.yaml
@@ -19,7 +19,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.jellyseerr.entrypoints: websecure
       traefik.http.routers.jellyseerr.middlewares: localaccess@file
       traefik.http.services.jellyseerr.loadbalancer.server.port: 5055
       homepage.group: Arr

--- a/docker/arr/jellyseerr.yaml
+++ b/docker/arr/jellyseerr.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.jellyseerr.entrypoints: websecure
-      traefik.http.routers.jellyseerr.middlewares: https-local@file
+      traefik.http.routers.jellyseerr.middlewares: localaccess@file
       traefik.http.services.jellyseerr.loadbalancer.server.port: 5055
       homepage.group: Arr
       homepage.name: Jellyseerr

--- a/docker/arr/prowlarr.yaml
+++ b/docker/arr/prowlarr.yaml
@@ -21,7 +21,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.prowlarr.entrypoints: websecure
       traefik.http.routers.prowlarr.middlewares: localaccess@file
       traefik.http.services.prowlarr.loadbalancer.server.port: 9696
       homepage.group: Arr

--- a/docker/arr/prowlarr.yaml
+++ b/docker/arr/prowlarr.yaml
@@ -22,7 +22,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.prowlarr.entrypoints: websecure
-      traefik.http.routers.prowlarr.middlewares: https-local@file
+      traefik.http.routers.prowlarr.middlewares: localaccess@file
       traefik.http.services.prowlarr.loadbalancer.server.port: 9696
       homepage.group: Arr
       homepage.name: Prowlarr

--- a/docker/arr/radarr.yaml
+++ b/docker/arr/radarr.yaml
@@ -21,7 +21,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.radarr.entrypoints: websecure
       traefik.http.routers.radarr.middlewares: localaccess@file
       traefik.http.services.radarr.loadbalancer.server.port: 7878
       homepage.group: Arr

--- a/docker/arr/radarr.yaml
+++ b/docker/arr/radarr.yaml
@@ -22,7 +22,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.radarr.entrypoints: websecure
-      traefik.http.routers.radarr.middlewares: https-local@file
+      traefik.http.routers.radarr.middlewares: localaccess@file
       traefik.http.services.radarr.loadbalancer.server.port: 7878
       homepage.group: Arr
       homepage.name: Radarr

--- a/docker/arr/readarr.yaml
+++ b/docker/arr/readarr.yaml
@@ -24,7 +24,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.readarr.entrypoints: websecure
-      traefik.http.routers.readarr.middlewares: https-local@file
+      traefik.http.routers.readarr.middlewares: localaccess@file
       traefik.http.services.readarr.loadbalancer.server.port: 8787
       homepage.group: Arr
       homepage.name: Readarr

--- a/docker/arr/readarr.yaml
+++ b/docker/arr/readarr.yaml
@@ -23,7 +23,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.readarr.entrypoints: websecure
       traefik.http.routers.readarr.middlewares: localaccess@file
       traefik.http.services.readarr.loadbalancer.server.port: 8787
       homepage.group: Arr

--- a/docker/arr/sonarr.yaml
+++ b/docker/arr/sonarr.yaml
@@ -22,7 +22,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.sonarr.entrypoints: websecure
       traefik.http.routers.sonarr.middlewares: localaccess@file
       traefik.http.services.sonarr.loadbalancer.server.port: 8989
       homepage.group: Arr

--- a/docker/arr/sonarr.yaml
+++ b/docker/arr/sonarr.yaml
@@ -23,7 +23,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.sonarr.entrypoints: websecure
-      traefik.http.routers.sonarr.middlewares: https-local@file
+      traefik.http.routers.sonarr.middlewares: localaccess@file
       traefik.http.services.sonarr.loadbalancer.server.port: 8989
       homepage.group: Arr
       homepage.name: Sonarr

--- a/docker/automation/homeassistant.yaml
+++ b/docker/automation/homeassistant.yaml
@@ -33,7 +33,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.homeassistant.entrypoints: websecure
-      traefik.http.routers.homeassistant.middlewares: https-local@file
+      traefik.http.routers.homeassistant.middlewares: localaccess@file
       traefik.http.routers.homeassistant.rule: Host(`ha.${MYDOMAIN}`)
       traefik.http.services.homeassistant.loadbalancer.server.port: 8123
       homepage.group: Automation

--- a/docker/automation/homeassistant.yaml
+++ b/docker/automation/homeassistant.yaml
@@ -32,7 +32,6 @@ services:
     #   - /path/to/device:/path/to/device  # optional
     labels:
       traefik.enable: true
-      traefik.http.routers.homeassistant.entrypoints: websecure
       traefik.http.routers.homeassistant.middlewares: localaccess@file
       traefik.http.routers.homeassistant.rule: Host(`ha.${MYDOMAIN}`)
       traefik.http.services.homeassistant.loadbalancer.server.port: 8123

--- a/docker/automation/n8n.yaml
+++ b/docker/automation/n8n.yaml
@@ -61,7 +61,6 @@ services:
         condition: service_healthy
     labels:
       traefik.enable: true
-      traefik.http.routers.n8n.entrypoints: websecure
       traefik.http.routers.n8n.middlewares: localaccess@file
       traefik.http.services.n8n.loadbalancer.server.port: 5678
       homepage.group: Automation

--- a/docker/automation/n8n.yaml
+++ b/docker/automation/n8n.yaml
@@ -62,7 +62,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.n8n.entrypoints: websecure
-      traefik.http.routers.n8n.middlewares: https-local@file
+      traefik.http.routers.n8n.middlewares: localaccess@file
       traefik.http.services.n8n.loadbalancer.server.port: 5678
       homepage.group: Automation
       homepage.name: n8n

--- a/docker/backup/kopia-b2.yaml
+++ b/docker/backup/kopia-b2.yaml
@@ -56,7 +56,6 @@ services:
 
     labels:
       traefik.enable: true
-      traefik.http.routers.kopia-b2.entrypoints: websecure
       traefik.http.routers.kopia-b2.middlewares: localaccess-sso@file
       traefik.http.services.kopia-b2.loadbalancer.server.port: 80
       homepage.group: Storage

--- a/docker/backup/kopia-b2.yaml
+++ b/docker/backup/kopia-b2.yaml
@@ -57,7 +57,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.kopia-b2.entrypoints: websecure
-      traefik.http.routers.kopia-b2.middlewares: https-local-auth@file
+      traefik.http.routers.kopia-b2.middlewares: localaccess-sso@file
       traefik.http.services.kopia-b2.loadbalancer.server.port: 80
       homepage.group: Storage
       homepage.name: Kopia - Backblaze B2

--- a/docker/backup/kopia-nas.yaml
+++ b/docker/backup/kopia-nas.yaml
@@ -55,7 +55,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.kopia-nas.entrypoints: websecure
-      traefik.http.routers.kopia-nas.middlewares: https-local-auth@file
+      traefik.http.routers.kopia-nas.middlewares: localaccess-sso@file
       traefik.http.services.kopia-nas.loadbalancer.server.port: 80
       homepage.group: Storage
       homepage.name: Kopia - NAS

--- a/docker/backup/kopia-nas.yaml
+++ b/docker/backup/kopia-nas.yaml
@@ -54,7 +54,6 @@ services:
 
     labels:
       traefik.enable: true
-      traefik.http.routers.kopia-nas.entrypoints: websecure
       traefik.http.routers.kopia-nas.middlewares: localaccess-sso@file
       traefik.http.services.kopia-nas.loadbalancer.server.port: 80
       homepage.group: Storage

--- a/docker/dashboard/homepage.yaml
+++ b/docker/dashboard/homepage.yaml
@@ -32,7 +32,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.homepage.entrypoints: websecure
       traefik.http.routers.homepage.rule: Host(`home.${MYDOMAIN}`)
       traefik.http.routers.homepage.middlewares: localaccess@file
       traefik.http.services.homepage.loadbalancer.server.port: 3000

--- a/docker/dashboard/homepage.yaml
+++ b/docker/dashboard/homepage.yaml
@@ -34,7 +34,7 @@ services:
       traefik.enable: true
       traefik.http.routers.homepage.entrypoints: websecure
       traefik.http.routers.homepage.rule: Host(`home.${MYDOMAIN}`)
-      traefik.http.routers.homepage.middlewares: https-local@file
+      traefik.http.routers.homepage.middlewares: localaccess@file
       traefik.http.services.homepage.loadbalancer.server.port: 3000
 
 networks:

--- a/docker/dev/code-server.yaml
+++ b/docker/dev/code-server.yaml
@@ -30,7 +30,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.code.entrypoints: websecure
-      traefik.http.routers.code.middlewares: https-local-auth@file
+      traefik.http.routers.code.middlewares: localaccess-sso@file
       traefik.http.routers.code.rule: Host(`code.${MYDOMAIN}`)
       traefik.http.services.code.loadbalancer.server.port: 8443
       homepage.group: Tools

--- a/docker/dev/code-server.yaml
+++ b/docker/dev/code-server.yaml
@@ -29,7 +29,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.code.entrypoints: websecure
       traefik.http.routers.code.middlewares: localaccess-sso@file
       traefik.http.routers.code.rule: Host(`code.${MYDOMAIN}`)
       traefik.http.services.code.loadbalancer.server.port: 8443

--- a/docker/dev/gitlab.yaml
+++ b/docker/dev/gitlab.yaml
@@ -39,7 +39,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.gitlab.entrypoints: websecure
-      traefik.http.routers.gitlab.middlewares: https-local@file
+      traefik.http.routers.gitlab.middlewares: localaccess@file
       traefik.http.services.gitlab.loadbalancer.server.port: 80
 
       homepage.group: Tools

--- a/docker/dev/gitlab.yaml
+++ b/docker/dev/gitlab.yaml
@@ -38,7 +38,6 @@ services:
 
     labels:
       traefik.enable: true
-      traefik.http.routers.gitlab.entrypoints: websecure
       traefik.http.routers.gitlab.middlewares: localaccess@file
       traefik.http.services.gitlab.loadbalancer.server.port: 80
 

--- a/docker/dev/jupyter-notebook.yaml
+++ b/docker/dev/jupyter-notebook.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.jupyter-notebook.entrypoints: websecure
-      traefik.http.routers.jupyter-notebook.middlewares: https-local@file
+      traefik.http.routers.jupyter-notebook.middlewares: localaccess@file
       traefik.http.routers.jupyter-notebook.rule: Host(`jupyter.${MYDOMAIN}`)
       traefik.http.services.jupyter-notebook.loadbalancer.server.port: 8888
       homepage.group: Tools

--- a/docker/dev/jupyter-notebook.yaml
+++ b/docker/dev/jupyter-notebook.yaml
@@ -19,7 +19,6 @@ services:
       - ${DOCKER_VOLUMES}/jupyter-notebook:/home/jovyan
     labels:
       traefik.enable: true
-      traefik.http.routers.jupyter-notebook.entrypoints: websecure
       traefik.http.routers.jupyter-notebook.middlewares: localaccess@file
       traefik.http.routers.jupyter-notebook.rule: Host(`jupyter.${MYDOMAIN}`)
       traefik.http.services.jupyter-notebook.loadbalancer.server.port: 8888

--- a/docker/fileshare/qbittorrent.yaml
+++ b/docker/fileshare/qbittorrent.yaml
@@ -35,7 +35,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.qbittorrent.entrypoints: websecure
-      traefik.http.routers.qbittorrent.middlewares: https-local-auth@file
+      traefik.http.routers.qbittorrent.middlewares: localaccess-sso@file
       traefik.http.services.qbittorrent.loadbalancer.server.port: 8080
       homepage.group: Arr
       homepage.name: qBittorrent

--- a/docker/fileshare/qbittorrent.yaml
+++ b/docker/fileshare/qbittorrent.yaml
@@ -34,7 +34,6 @@ services:
       - 6881:6881/udp # Bittorrent incoming connections
     labels:
       traefik.enable: true
-      traefik.http.routers.qbittorrent.entrypoints: websecure
       traefik.http.routers.qbittorrent.middlewares: localaccess-sso@file
       traefik.http.services.qbittorrent.loadbalancer.server.port: 8080
       homepage.group: Arr

--- a/docker/infra/adguardhome.yaml
+++ b/docker/infra/adguardhome.yaml
@@ -36,7 +36,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.adguardhome.entrypoints: websecure
       traefik.http.routers.adguardhome.middlewares: localaccess@file
       traefik.http.services.adguardhome.loadbalancer.server.port: 3000
       homepage.group: Infra

--- a/docker/infra/adguardhome.yaml
+++ b/docker/infra/adguardhome.yaml
@@ -37,7 +37,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.adguardhome.entrypoints: websecure
-      traefik.http.routers.adguardhome.middlewares: https-local@file
+      traefik.http.routers.adguardhome.middlewares: localaccess@file
       traefik.http.services.adguardhome.loadbalancer.server.port: 3000
       homepage.group: Infra
       homepage.name: AdGuard Home

--- a/docker/infra/portainer.yaml
+++ b/docker/infra/portainer.yaml
@@ -24,7 +24,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.portainer.entrypoints: websecure
-      traefik.http.routers.portainer.middlewares: https-local@file
+      traefik.http.routers.portainer.middlewares: localaccess@file
       traefik.http.services.portainer.loadbalancer.server.port: 9000
       homepage.group: Infra
       homepage.name: Portainer

--- a/docker/infra/portainer.yaml
+++ b/docker/infra/portainer.yaml
@@ -23,7 +23,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.portainer.entrypoints: websecure
       traefik.http.routers.portainer.middlewares: localaccess@file
       traefik.http.services.portainer.loadbalancer.server.port: 9000
       homepage.group: Infra

--- a/docker/infra/unifi-controller.yaml
+++ b/docker/infra/unifi-controller.yaml
@@ -42,7 +42,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.unifi-controller.entrypoints: websecure
-      traefik.http.routers.unifi-controller.middlewares: https-local@file
+      traefik.http.routers.unifi-controller.middlewares: localaccess@file
       traefik.http.services.unifi-controller.loadbalancer.server.port: 8443
       traefik.http.services.unifi-controller.loadbalancer.server.scheme: https
       traefik.http.services.unifi-controller.loadbalancer.serversTransport: insecureTransport@file

--- a/docker/infra/unifi-controller.yaml
+++ b/docker/infra/unifi-controller.yaml
@@ -41,7 +41,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.unifi-controller.entrypoints: websecure
       traefik.http.routers.unifi-controller.middlewares: localaccess@file
       traefik.http.services.unifi-controller.loadbalancer.server.port: 8443
       traefik.http.services.unifi-controller.loadbalancer.server.scheme: https

--- a/docker/media/audio/navidrome.yaml
+++ b/docker/media/audio/navidrome.yaml
@@ -33,7 +33,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.navidrome.entrypoints: websecure
       traefik.http.routers.navidrome.middlewares: localaccess@file
       traefik.http.services.navidrome.loadbalancer.server.port: 4533
       homepage.group: Media

--- a/docker/media/audio/navidrome.yaml
+++ b/docker/media/audio/navidrome.yaml
@@ -34,7 +34,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.navidrome.entrypoints: websecure
-      traefik.http.routers.navidrome.middlewares: https-local@file
+      traefik.http.routers.navidrome.middlewares: localaccess@file
       traefik.http.services.navidrome.loadbalancer.server.port: 4533
       homepage.group: Media
       homepage.name: Navidrome

--- a/docker/media/ebook/calibre-web.yaml
+++ b/docker/media/ebook/calibre-web.yaml
@@ -25,7 +25,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.calibre-web.entrypoints: websecure
       traefik.http.routers.calibre-web.middlewares: localaccess@file
       traefik.http.services.calibre-web.loadbalancer.server.port: 8083
       homepage.group: Media

--- a/docker/media/ebook/calibre-web.yaml
+++ b/docker/media/ebook/calibre-web.yaml
@@ -26,7 +26,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.calibre-web.entrypoints: websecure
-      traefik.http.routers.calibre-web.middlewares: https-local@file
+      traefik.http.routers.calibre-web.middlewares: localaccess@file
       traefik.http.services.calibre-web.loadbalancer.server.port: 8083
       homepage.group: Media
       homepage.name: Calibre-web

--- a/docker/media/ebook/calibre.yaml
+++ b/docker/media/ebook/calibre.yaml
@@ -40,7 +40,6 @@ services:
 
       # Desktop GUI (via KasmVNC)
       traefik.http.routers.calibre.service: calibre
-      traefik.http.routers.calibre.entrypoints: websecure
       traefik.http.routers.calibre.middlewares: localaccess@file
       traefik.http.services.calibre.loadbalancer.server.port: 8080
 
@@ -48,7 +47,6 @@ services:
       # URL: https://calibre-server.${MYDOMAIN}/opds
       # Set Preferences -> Sharing over the net -> Advanced -> Authentication: basic
       traefik.http.routers.calibre-server.service: calibre-server
-      traefik.http.routers.calibre-server.entrypoints: websecure
       traefik.http.routers.calibre-server.middlewares: localaccess@file
       traefik.http.routers.calibre-server.rule: Host(`calibre-server.${MYDOMAIN}`)
       traefik.http.services.calibre-server.loadbalancer.server.port: 8081

--- a/docker/media/ebook/calibre.yaml
+++ b/docker/media/ebook/calibre.yaml
@@ -41,7 +41,7 @@ services:
       # Desktop GUI (via KasmVNC)
       traefik.http.routers.calibre.service: calibre
       traefik.http.routers.calibre.entrypoints: websecure
-      traefik.http.routers.calibre.middlewares: https-local@file
+      traefik.http.routers.calibre.middlewares: localaccess@file
       traefik.http.services.calibre.loadbalancer.server.port: 8080
 
       # Content Server (OPDS Catalog)
@@ -49,7 +49,7 @@ services:
       # Set Preferences -> Sharing over the net -> Advanced -> Authentication: basic
       traefik.http.routers.calibre-server.service: calibre-server
       traefik.http.routers.calibre-server.entrypoints: websecure
-      traefik.http.routers.calibre-server.middlewares: https-local@file
+      traefik.http.routers.calibre-server.middlewares: localaccess@file
       traefik.http.routers.calibre-server.rule: Host(`calibre-server.${MYDOMAIN}`)
       traefik.http.services.calibre-server.loadbalancer.server.port: 8081
 

--- a/docker/media/ebook/kiwix-serve.yaml
+++ b/docker/media/ebook/kiwix-serve.yaml
@@ -24,7 +24,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.kiwix-serve.entrypoints: websecure
-      traefik.http.routers.kiwix-serve.middlewares: https-local@file
+      traefik.http.routers.kiwix-serve.middlewares: localaccess@file
       traefik.http.routers.kiwix-serve.rule: Host(`kiwix.${MYDOMAIN}`)
       traefik.http.services.kiwix-serve.loadbalancer.server.port: 8080
       homepage.group: Media

--- a/docker/media/ebook/kiwix-serve.yaml
+++ b/docker/media/ebook/kiwix-serve.yaml
@@ -23,7 +23,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.kiwix-serve.entrypoints: websecure
       traefik.http.routers.kiwix-serve.middlewares: localaccess@file
       traefik.http.routers.kiwix-serve.rule: Host(`kiwix.${MYDOMAIN}`)
       traefik.http.services.kiwix-serve.loadbalancer.server.port: 8080

--- a/docker/media/video/jellyfin-vue.yaml
+++ b/docker/media/video/jellyfin-vue.yaml
@@ -14,7 +14,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.jellyfin-vue.entrypoints: websecure
-      traefik.http.routers.jellyfin-vue.middlewares: https-local@file
+      traefik.http.routers.jellyfin-vue.middlewares: localaccess@file
       traefik.http.services.jellyfin-vue.loadbalancer.server.port: 80
       homepage.group: Media
       homepage.name: Jellyfin-vue

--- a/docker/media/video/jellyfin-vue.yaml
+++ b/docker/media/video/jellyfin-vue.yaml
@@ -13,7 +13,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.jellyfin-vue.entrypoints: websecure
       traefik.http.routers.jellyfin-vue.middlewares: localaccess@file
       traefik.http.services.jellyfin-vue.loadbalancer.server.port: 80
       homepage.group: Media

--- a/docker/media/video/jellyfin.yaml
+++ b/docker/media/video/jellyfin.yaml
@@ -32,7 +32,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.jellyfin.entrypoints: websecure
-      traefik.http.routers.jellyfin.middlewares: https-public@file
+      traefik.http.routers.jellyfin.middlewares: publicaccess@file
       traefik.http.services.jellyfin.loadbalancer.server.port: 8096
       homepage.group: Media
       homepage.name: Jellyfin

--- a/docker/media/video/jellyfin.yaml
+++ b/docker/media/video/jellyfin.yaml
@@ -31,7 +31,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.jellyfin.entrypoints: websecure
       traefik.http.routers.jellyfin.middlewares: publicaccess@file
       traefik.http.services.jellyfin.loadbalancer.server.port: 8096
       homepage.group: Media

--- a/docker/media/video/metube.yaml
+++ b/docker/media/video/metube.yaml
@@ -22,7 +22,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.metube.entrypoints: websecure
       traefik.http.routers.metube.middlewares: localaccess@file
       traefik.http.services.metube.loadbalancer.server.port: 8081
       homepage.group: Media

--- a/docker/media/video/metube.yaml
+++ b/docker/media/video/metube.yaml
@@ -23,7 +23,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.metube.entrypoints: websecure
-      traefik.http.routers.metube.middlewares: https-local@file
+      traefik.http.routers.metube.middlewares: localaccess@file
       traefik.http.services.metube.loadbalancer.server.port: 8081
       homepage.group: Media
       homepage.name: Metube

--- a/docker/monitoring/grafana.yaml
+++ b/docker/monitoring/grafana.yaml
@@ -26,7 +26,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.grafana.entrypoints: websecure
       traefik.http.routers.grafana.middlewares: localaccess@file
       traefik.http.services.grafana.loadbalancer.server.port: 3000
       homepage.group: Monitoring

--- a/docker/monitoring/grafana.yaml
+++ b/docker/monitoring/grafana.yaml
@@ -27,7 +27,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.grafana.entrypoints: websecure
-      traefik.http.routers.grafana.middlewares: https-local@file
+      traefik.http.routers.grafana.middlewares: localaccess@file
       traefik.http.services.grafana.loadbalancer.server.port: 3000
       homepage.group: Monitoring
       homepage.name: Grafana

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -26,7 +26,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.prometheus.entrypoints: websecure
-      traefik.http.routers.prometheus.middlewares: https-local@file
+      traefik.http.routers.prometheus.middlewares: localaccess@file
       traefik.http.services.prometheus.loadbalancer.server.port: 9090
       homepage.group: Monitoring
       homepage.name: Prometheus

--- a/docker/monitoring/prometheus.yaml
+++ b/docker/monitoring/prometheus.yaml
@@ -25,7 +25,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.prometheus.entrypoints: websecure
       traefik.http.routers.prometheus.middlewares: localaccess@file
       traefik.http.services.prometheus.loadbalancer.server.port: 9090
       homepage.group: Monitoring

--- a/docker/monitoring/scrutiny.yaml
+++ b/docker/monitoring/scrutiny.yaml
@@ -43,7 +43,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.scrutiny.entrypoints: websecure
-      traefik.http.routers.scrutiny.middlewares: https-local@file
+      traefik.http.routers.scrutiny.middlewares: localaccess@file
       traefik.http.routers.scrutiny.rule: Host(`scrutiny.${MYDOMAIN}`)
       traefik.http.services.scrutiny.loadbalancer.server.port: 8080
       homepage.group: Monitoring

--- a/docker/monitoring/scrutiny.yaml
+++ b/docker/monitoring/scrutiny.yaml
@@ -42,7 +42,6 @@ services:
       start_period: 10s
     labels:
       traefik.enable: true
-      traefik.http.routers.scrutiny.entrypoints: websecure
       traefik.http.routers.scrutiny.middlewares: localaccess@file
       traefik.http.routers.scrutiny.rule: Host(`scrutiny.${MYDOMAIN}`)
       traefik.http.services.scrutiny.loadbalancer.server.port: 8080

--- a/docker/monitoring/uptime-kuma.yaml
+++ b/docker/monitoring/uptime-kuma.yaml
@@ -20,7 +20,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.uptime-kuma.entrypoints: websecure
-      traefik.http.routers.uptime-kuma.middlewares: https-local-auth@file
+      traefik.http.routers.uptime-kuma.middlewares: localaccess-sso@file
       traefik.http.services.uptime-kuma.loadbalancer.server.port: 3001
       homepage.group: Monitoring
       homepage.name: Uptime Kuma

--- a/docker/monitoring/uptime-kuma.yaml
+++ b/docker/monitoring/uptime-kuma.yaml
@@ -19,7 +19,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.uptime-kuma.entrypoints: websecure
       traefik.http.routers.uptime-kuma.middlewares: localaccess-sso@file
       traefik.http.services.uptime-kuma.loadbalancer.server.port: 3001
       homepage.group: Monitoring

--- a/docker/security/authelia.yaml
+++ b/docker/security/authelia.yaml
@@ -48,7 +48,6 @@ services:
         condition: service_completed_successfully
     labels:
       traefik.enable: true
-      traefik.http.routers.authelia.entrypoints: websecure
       traefik.http.routers.authelia.rule: Host(`auth.${MYDOMAIN}`)
       traefik.http.routers.authelia.middlewares: localaccess@file
       traefik.http.services.authelia.loadbalancer.server.port: 9091

--- a/docker/security/authelia.yaml
+++ b/docker/security/authelia.yaml
@@ -50,7 +50,7 @@ services:
       traefik.enable: true
       traefik.http.routers.authelia.entrypoints: websecure
       traefik.http.routers.authelia.rule: Host(`auth.${MYDOMAIN}`)
-      traefik.http.routers.authelia.middlewares: https-local@file
+      traefik.http.routers.authelia.middlewares: localaccess@file
       traefik.http.services.authelia.loadbalancer.server.port: 9091
       homepage.group: Security
       homepage.name: Authelia

--- a/docker/security/traefik.yaml
+++ b/docker/security/traefik.yaml
@@ -39,7 +39,7 @@ services:
       traefik.enable: true
       traefik.http.routers.api.rule: Host(`traefik.${MYDOMAIN}`) # Define the subdomain for the traefik dashboard
       traefik.http.routers.api.service: api@internal # Enable Traefik API
-      traefik.http.routers.api.middlewares: https-local@file
+      traefik.http.routers.api.middlewares: localaccess@file
       homepage.group: Infra
       homepage.name: Traefik
       homepage.icon: traefik.png

--- a/docker/security/traefik.yaml
+++ b/docker/security/traefik.yaml
@@ -8,7 +8,7 @@
 name: traefik
 services:
   traefik:
-    image: traefik:v3.3
+    image: traefik:v3.3.1
     container_name: traefik
     restart: unless-stopped
     environment:
@@ -17,13 +17,12 @@ services:
       MAIN_NODE_IP: ${MAIN_NODE_IP}
       CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
       # Used in static configuration (traefik.yml)
-      # TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE: 'Host(`{{ index .Labels "com.docker.compose.service"}}.${MYDOMAIN}`)'
       TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_MAIN: "${MYDOMAIN}"
       TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_SANS: "*.${MYDOMAIN}"
       TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: "${ADMIN_EMAIL}"
     volumes:
       # kics-scan ignore-line
-      - /var/run/docker.sock:/var/run/docker.sock:ro # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock:ro # So that Traefik can listen to the Docker events # TODO To improve the security use a docker socket proxy
       - ./traefik:/etc/traefik/
       - ${DOCKER_VOLUMES}/traefik/logs:/logs
       - ${DOCKER_VOLUMES}/traefik/letsencrypt:/letsencrypt

--- a/docker/security/traefik/dynamic/external-services.yml
+++ b/docker/security/traefik/dynamic/external-services.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://json.schemastore.org/traefik-v3.json
+
+# Dynamic configuration - changes in this file are applied without restarting Traefik (https://doc.traefik.io/traefik/providers/file/#watch).
+# Configuration via environment variables: use go templating, like {{env "VARIABLENAME"}}
+
+http:
+
+  routers:
+    router:
+      rule: 'Host(`router.{{env "MYDOMAIN"}}`)'
+      service: router
+      middlewares:
+        - localaccess@file
+    proxmox:
+      rule: 'Host(`proxmox.{{env "MYDOMAIN"}}`)'
+      service: proxmox
+      middlewares:
+        - localaccess@file
+    qbittorrent:
+      rule: 'Host(`qbittorrent.{{env "MYDOMAIN"}}`)'
+      service: qbittorrent
+      middlewares:
+        - localaccess-sso@file
+
+  services:
+    router:
+      loadBalancer:
+        serversTransport: insecureTransport
+        servers:
+          - url: http://192.168.1.1:80
+    proxmox:
+      loadBalancer:
+        serversTransport: insecureTransport
+        servers:
+          - url: https://192.168.1.50:8006
+    qbittorrent:
+      loadBalancer:
+        serversTransport: insecureTransport
+        servers:
+          - url: http://nas:8080

--- a/docker/security/traefik/dynamic/middlewares.yml
+++ b/docker/security/traefik/dynamic/middlewares.yml
@@ -1,74 +1,39 @@
+# yaml-language-server: $schema=https://json.schemastore.org/traefik-v3.json
+
 # Dynamic configuration - changes in this file are applied without restarting Traefik (https://doc.traefik.io/traefik/providers/file/#watch).
 # Configuration via environment variables: use go templating, like {{env "VARIABLENAME"}}
 
 http:
 
-  routers:
-    router:
-      rule: 'Host(`router.{{env "MYDOMAIN"}}`)'
-      service: router
-      middlewares:
-        - "https-local@file"
-    proxmox:
-      rule: 'Host(`proxmox.{{env "MYDOMAIN"}}`)'
-      service: proxmox
-      middlewares:
-        - "https-local@file"
-    qbittorrent:
-      rule: 'Host(`qbittorrent.{{env "MYDOMAIN"}}`)'
-      service: qbittorrent
-      middlewares:
-        - "https-local-auth@file"
-
-  services:
-    router:
-      loadBalancer:
-        serversTransport: insecureTransport
-        servers:
-          - url: http://192.168.1.1:80
-    proxmox:
-      loadBalancer:
-        serversTransport: insecureTransport
-        servers:
-          - url: https://192.168.1.50:8006
-    qbittorrent:
-      loadBalancer:
-        serversTransport: insecureTransport
-        servers:
-          - url: http://nas:8080
-
-  # allow self-signed certificates for proxied web services
+  # Allow self-signed certificates for proxied web services
   serversTransports:
     insecureTransport:
       insecureSkipVerify: true
 
   ## MIDDLEWARES ##
   middlewares:
-    https-public:
+    localaccess:
       chain:
         middlewares:
-          - https-only
-          - crowdsec-bouncer
-          # - security-headers
-
-    https-local:
-      chain:
-        middlewares:
-          - https-only
           - local-ip-allowlist
 
-    https-local-auth:
+    localaccess-sso:
       chain:
         middlewares:
-          - https-only
           - local-ip-allowlist
           - authelia
+
+    publicaccess:
+      chain:
+        middlewares:
+          - crowdsec-bouncer
+          # - security-headers
 
     https-only:
       redirectScheme:
         scheme: https
 
-    # Only Allow Local networks
+    # Allow only local networks
     local-ip-allowlist:
       ipAllowList:
         sourceRange:
@@ -88,7 +53,6 @@ http:
         address: http://bouncer-traefik:8080/api/v1/forwardAuth
         trustForwardHeader: true
 
-    # Security headers
     security-headers:
       headers:
         customResponseHeaders: # field names are case-insensitive
@@ -113,11 +77,17 @@ http:
         # contentSecurityPolicy: "block-all-mixed-content" # Content-Security-Policy (CSP)
 
 
-# Only use secure ciphers - https://ssl-config.mozilla.org/#server=traefik&version=2.9&config=intermediate&guideline=5.6
+# Only use secure ciphers
+# Generated with Mozilla SSL Configuration Generator
+# https://ssl-config.mozilla.org/#server=traefik&version=3.2.1&config=intermediate&guideline=5.7
 tls:
   options:
     default:
       minVersion: VersionTLS12
+      curvePreferences:
+        - X25519
+        - CurveP256
+        - CurveP384
       cipherSuites:
         - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

--- a/docker/security/traefik/fileConfig.yml
+++ b/docker/security/traefik/fileConfig.yml
@@ -5,22 +5,16 @@ http:
 
   routers:
     router:
-      entryPoints:
-        - websecure
       rule: 'Host(`router.{{env "MYDOMAIN"}}`)'
       service: router
       middlewares:
         - "https-local@file"
     proxmox:
-      entryPoints:
-        - websecure
       rule: 'Host(`proxmox.{{env "MYDOMAIN"}}`)'
       service: proxmox
       middlewares:
         - "https-local@file"
     qbittorrent:
-      entryPoints:
-        - websecure
       rule: 'Host(`qbittorrent.{{env "MYDOMAIN"}}`)'
       service: qbittorrent
       middlewares:

--- a/docker/security/traefik/traefik.yml
+++ b/docker/security/traefik/traefik.yml
@@ -1,12 +1,12 @@
+# yaml-language-server: $schema=https://json.schemastore.org/traefik-v3.json
+
 # Static configuration - restart Traefik to apply the changes
 # Configuration via environment variables: https://doc.traefik.io/traefik/reference/static-configuration/env/
 
-# Traefik global configuration
 global:
   checkNewVersion: false
   sendAnonymousUsage: false
 
-# Enable traefik UI dashboard
 api:
   dashboard: true
 
@@ -23,34 +23,56 @@ providers:
 
   # File provider for connecting things that are outside of docker / defining middleware
   file:
-    filename: /etc/traefik/fileConfig.yml
+    directory: /etc/traefik/dynamic
     watch: true
 
   # Docker provider for connecting all apps that are inside of the docker network
   docker:
     watch: true
     network: proxy
-    # Default host rule to containername.domain.example
-    defaultRule: 'Host(`{{ index .Labels "com.docker.compose.service"}}.{{env "MYDOMAIN"}}`)'
-    exposedByDefault: false  # Tells Traefik not to expose containers to the outside world unless explicitly instructed to do so
+    defaultRule: 'Host(`{{ index .Labels "com.docker.compose.service"}}.{{env "MYDOMAIN"}}`)'  # Default host rule: containername.domain.tld
+    exposedByDefault: false  # Do not expose containers to the outside world unless explicitly configured
 
 entryPoints:
+  # !!! If there is no TLS certificate available:
+  #   - Enable this entrypoint
+  #   - Disable the other 'web' entrypoint
+  #   - WARNING: this is an insecure configuration, not recommended to use
+  #   - Note: Additional setup is needed to enable inter-service communication, links on the dashboard, etc.
+  #     See this PR for the necessary changes: https://github.com/bubacoder/infra/pull/85
+  #
+  # HTTP entrypoint, listen on port 80, redirect to https
+  # web:
+  #   address: :80
+  #   asDefault: true
+
+  # !!! If an TLS certificate is configured:
+  #   - Enable this entrypoint (will redirect to HTTPS)
+  #   - Disable the other 'web' entrypoint
+  #
+  # HTTP entrypoint, listen on port 80, redirect all HTTP traffic to the HTTPS entrypoint
   web:
-    address: :80 # Configures the HTTP entrypoint to listen on port 80
+    address: :80
+    asDefault: false
     http:
       redirections:
         entryPoint:
-          to: websecure # Redirects all HTTP traffic to the HTTPS entrypoint
+          to: websecure
           scheme: https
+
+  # HTTPS entrypoint, listen on port 443
+  # Note: Two entrypoints cannot listen on the same port
   websecure:
-    address: :443 # Configures the HTTPS entrypoint to listen on port 443
+    address: :443
+    asDefault: true
     http3:
       advertisedPort: 443
     http:
       tls:
-        # minVersion: VersionTLS12 # Enforces TLS 1.2 or better
         certResolver: letsencrypt # Configures the HTTPS entrypoint to use certificates obtained from the Let's Encrypt CA
         # domains: -> configured by TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_* env var
+      middlewares:
+        - https-only@file
 
 # https://doc.traefik.io/traefik/user-guides/docker-compose/acme-dns/
 # OVH:

--- a/docker/security/wg-easy.yaml
+++ b/docker/security/wg-easy.yaml
@@ -34,7 +34,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.wireguard.entrypoints: websecure
       traefik.http.routers.wireguard.rule: Host(`vpn.${MYDOMAIN}`)
       traefik.http.routers.wireguard.middlewares: localaccess-sso@file
       traefik.http.services.wireguard.loadbalancer.server.port: 51821

--- a/docker/security/wg-easy.yaml
+++ b/docker/security/wg-easy.yaml
@@ -36,7 +36,7 @@ services:
       traefik.enable: true
       traefik.http.routers.wireguard.entrypoints: websecure
       traefik.http.routers.wireguard.rule: Host(`vpn.${MYDOMAIN}`)
-      traefik.http.routers.wireguard.middlewares: https-local-auth@file
+      traefik.http.routers.wireguard.middlewares: localaccess-sso@file
       traefik.http.services.wireguard.loadbalancer.server.port: 51821
       homepage.group: Security
       homepage.name: WireGuard Easy

--- a/docker/storage/filebrowser.yaml
+++ b/docker/storage/filebrowser.yaml
@@ -23,7 +23,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.filebrowser.entrypoints: websecure
       traefik.http.routers.filebrowser.middlewares: localaccess@file
       traefik.http.services.filebrowser.loadbalancer.server.port: 80
       homepage.group: Storage

--- a/docker/storage/filebrowser.yaml
+++ b/docker/storage/filebrowser.yaml
@@ -24,7 +24,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.filebrowser.entrypoints: websecure
-      traefik.http.routers.filebrowser.middlewares: https-local@file
+      traefik.http.routers.filebrowser.middlewares: localaccess@file
       traefik.http.services.filebrowser.loadbalancer.server.port: 80
       homepage.group: Storage
       homepage.name: Filebrowser

--- a/docker/storage/minio.yaml
+++ b/docker/storage/minio.yaml
@@ -43,14 +43,14 @@ services:
       traefik.http.routers.minio.service: minio
       traefik.http.routers.minio.entrypoints: websecure
       traefik.http.routers.minio.rule: Host(`s3.${MYDOMAIN}`)
-      traefik.http.routers.minio.middlewares: https-local@file
+      traefik.http.routers.minio.middlewares: localaccess@file
       traefik.http.services.minio.loadbalancer.server.port: 9000
 
       # Console
       traefik.http.routers.minio-console.service: minio-console
       traefik.http.routers.minio-console.entrypoints: websecure
       traefik.http.routers.minio-console.rule: Host(`minio-console.${MYDOMAIN}`)
-      traefik.http.routers.minio-console.middlewares: https-local@file
+      traefik.http.routers.minio-console.middlewares: localaccess@file
       traefik.http.services.minio-console.loadbalancer.server.port: 9001
 
       homepage.group: Storage

--- a/docker/storage/minio.yaml
+++ b/docker/storage/minio.yaml
@@ -41,14 +41,12 @@ services:
 
       # S3 API
       traefik.http.routers.minio.service: minio
-      traefik.http.routers.minio.entrypoints: websecure
       traefik.http.routers.minio.rule: Host(`s3.${MYDOMAIN}`)
       traefik.http.routers.minio.middlewares: localaccess@file
       traefik.http.services.minio.loadbalancer.server.port: 9000
 
       # Console
       traefik.http.routers.minio-console.service: minio-console
-      traefik.http.routers.minio-console.entrypoints: websecure
       traefik.http.routers.minio-console.rule: Host(`minio-console.${MYDOMAIN}`)
       traefik.http.routers.minio-console.middlewares: localaccess@file
       traefik.http.services.minio-console.loadbalancer.server.port: 9001

--- a/docker/storage/syncthing.yaml
+++ b/docker/storage/syncthing.yaml
@@ -26,7 +26,6 @@ services:
     #   - 21027:21027/udp
     labels:
       traefik.enable: true
-      traefik.http.routers.syncthing.entrypoints: websecure
       traefik.http.routers.syncthing.middlewares: localaccess-sso@file
       traefik.http.services.syncthing.loadbalancer.server.port: 8384
       homepage.group: Storage

--- a/docker/storage/syncthing.yaml
+++ b/docker/storage/syncthing.yaml
@@ -27,7 +27,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.syncthing.entrypoints: websecure
-      traefik.http.routers.syncthing.middlewares: https-local-auth@file
+      traefik.http.routers.syncthing.middlewares: localaccess-sso@file
       traefik.http.services.syncthing.loadbalancer.server.port: 8384
       homepage.group: Storage
       homepage.name: Syncthing

--- a/docker/storage/webdav.yaml
+++ b/docker/storage/webdav.yaml
@@ -33,7 +33,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.webdav.entrypoints: websecure
-      traefik.http.routers.webdav.middlewares: https-local@file
+      traefik.http.routers.webdav.middlewares: localaccess@file
       traefik.http.services.webdav.loadbalancer.server.port: 80
       homepage.group: Storage
       homepage.name: WebDAV

--- a/docker/storage/webdav.yaml
+++ b/docker/storage/webdav.yaml
@@ -32,7 +32,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.webdav.entrypoints: websecure
       traefik.http.routers.webdav.middlewares: localaccess@file
       traefik.http.services.webdav.loadbalancer.server.port: 80
       homepage.group: Storage

--- a/docker/tools/cyberchef.yaml
+++ b/docker/tools/cyberchef.yaml
@@ -13,7 +13,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.cyberchef.entrypoints: websecure
       traefik.http.routers.cyberchef.middlewares: localaccess@file
       traefik.http.services.cyberchef.loadbalancer.server.port: 8000
       homepage.group: Tools

--- a/docker/tools/cyberchef.yaml
+++ b/docker/tools/cyberchef.yaml
@@ -14,7 +14,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.cyberchef.entrypoints: websecure
-      traefik.http.routers.cyberchef.middlewares: https-local@file
+      traefik.http.routers.cyberchef.middlewares: localaccess@file
       traefik.http.services.cyberchef.loadbalancer.server.port: 8000
       homepage.group: Tools
       homepage.name: Cyberchef

--- a/docker/tools/guacamole.yaml
+++ b/docker/tools/guacamole.yaml
@@ -21,7 +21,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.guacamole.entrypoints: websecure
-      traefik.http.routers.guacamole.middlewares: https-local@file
+      traefik.http.routers.guacamole.middlewares: localaccess@file
       traefik.http.services.guacamole.loadbalancer.server.port: 8080
       homepage.group: Connections
       homepage.name: Guacamole

--- a/docker/tools/guacamole.yaml
+++ b/docker/tools/guacamole.yaml
@@ -20,7 +20,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.guacamole.entrypoints: websecure
       traefik.http.routers.guacamole.middlewares: localaccess@file
       traefik.http.services.guacamole.loadbalancer.server.port: 8080
       homepage.group: Connections

--- a/docker/tools/homelab-docs.yaml
+++ b/docker/tools/homelab-docs.yaml
@@ -11,7 +11,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.homelab-docs.entrypoints: websecure
       traefik.http.routers.homelab-docs.middlewares: localaccess@file
       traefik.http.routers.homelab-docs.rule: Host(`docs.${MYDOMAIN}`)
       traefik.http.services.homelab-docs.loadbalancer.server.port: 80

--- a/docker/tools/homelab-docs.yaml
+++ b/docker/tools/homelab-docs.yaml
@@ -12,7 +12,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.homelab-docs.entrypoints: websecure
-      traefik.http.routers.homelab-docs.middlewares: https-local@file
+      traefik.http.routers.homelab-docs.middlewares: localaccess@file
       traefik.http.routers.homelab-docs.rule: Host(`docs.${MYDOMAIN}`)
       traefik.http.services.homelab-docs.loadbalancer.server.port: 80
       homepage.group: Tools

--- a/docker/tools/kasm.yaml
+++ b/docker/tools/kasm.yaml
@@ -50,7 +50,7 @@ services:
       # User interface
       traefik.http.routers.kasm.service: kasm
       traefik.http.routers.kasm.entrypoints: websecure
-      traefik.http.routers.kasm.middlewares: https-local@file
+      traefik.http.routers.kasm.middlewares: localaccess@file
       traefik.http.services.kasm.loadbalancer.server.port: 443
       traefik.http.services.kasm.loadbalancer.server.scheme: https
       traefik.http.services.kasm.loadbalancer.serversTransport: insecureTransport@file
@@ -58,7 +58,7 @@ services:
       # Initial setup interface
       traefik.http.routers.kasm-install.service: kasm-install
       traefik.http.routers.kasm-install.entrypoints: websecure
-      traefik.http.routers.kasm-install.middlewares: https-local@file
+      traefik.http.routers.kasm-install.middlewares: localaccess@file
       traefik.http.routers.kasm-install.rule: Host(`kasm-install.${MYDOMAIN}`)
       traefik.http.services.kasm-install.loadbalancer.server.port: 3000 # https
       traefik.http.services.kasm-install.loadbalancer.server.scheme: https

--- a/docker/tools/kasm.yaml
+++ b/docker/tools/kasm.yaml
@@ -49,7 +49,6 @@ services:
 
       # User interface
       traefik.http.routers.kasm.service: kasm
-      traefik.http.routers.kasm.entrypoints: websecure
       traefik.http.routers.kasm.middlewares: localaccess@file
       traefik.http.services.kasm.loadbalancer.server.port: 443
       traefik.http.services.kasm.loadbalancer.server.scheme: https
@@ -57,7 +56,6 @@ services:
 
       # Initial setup interface
       traefik.http.routers.kasm-install.service: kasm-install
-      traefik.http.routers.kasm-install.entrypoints: websecure
       traefik.http.routers.kasm-install.middlewares: localaccess@file
       traefik.http.routers.kasm-install.rule: Host(`kasm-install.${MYDOMAIN}`)
       traefik.http.services.kasm-install.loadbalancer.server.port: 3000 # https

--- a/docker/tools/openspeedtest.yaml
+++ b/docker/tools/openspeedtest.yaml
@@ -12,7 +12,7 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.openspeedtest.middlewares: https-public@file
+      traefik.http.routers.openspeedtest.middlewares: publicaccess@file
       traefik.http.routers.openspeedtest.rule: Host(`speedtest.${MYDOMAIN}`)
       traefik.http.services.openspeedtest.loadbalancer.server.port: 3000
       homepage.group: Tools

--- a/docker/tools/searxng.yaml
+++ b/docker/tools/searxng.yaml
@@ -64,7 +64,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.searxng.entrypoints: websecure
       traefik.http.routers.searxng.middlewares: localaccess@file
       traefik.http.services.searxng.loadbalancer.server.port: 8080
       homepage.group: Tools

--- a/docker/tools/searxng.yaml
+++ b/docker/tools/searxng.yaml
@@ -65,7 +65,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.searxng.entrypoints: websecure
-      traefik.http.routers.searxng.middlewares: https-local@file
+      traefik.http.routers.searxng.middlewares: localaccess@file
       traefik.http.services.searxng.loadbalancer.server.port: 8080
       homepage.group: Tools
       homepage.name: SearXNG

--- a/docker/tools/stirling-pdf.yaml
+++ b/docker/tools/stirling-pdf.yaml
@@ -22,7 +22,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.stirling-pdf.entrypoints: websecure
-      traefik.http.routers.stirling-pdf.middlewares: https-local@file
+      traefik.http.routers.stirling-pdf.middlewares: localaccess@file
       traefik.http.services.stirling-pdf.loadbalancer.server.port: 8080
       homepage.group: Tools
       homepage.name: Stirling PDF

--- a/docker/tools/stirling-pdf.yaml
+++ b/docker/tools/stirling-pdf.yaml
@@ -21,7 +21,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.stirling-pdf.entrypoints: websecure
       traefik.http.routers.stirling-pdf.middlewares: localaccess@file
       traefik.http.services.stirling-pdf.loadbalancer.server.port: 8080
       homepage.group: Tools

--- a/docker/tools/vaultwarden.yaml
+++ b/docker/tools/vaultwarden.yaml
@@ -22,7 +22,6 @@ services:
       - proxy
     labels:
       traefik.enable: true
-      traefik.http.routers.vault.entrypoints: websecure
       traefik.http.routers.vault.middlewares: localaccess@file
       traefik.http.routers.vault.rule: Host(`vault.${MYDOMAIN}`)
       traefik.http.services.vault.loadbalancer.server.port: 80

--- a/docker/tools/vaultwarden.yaml
+++ b/docker/tools/vaultwarden.yaml
@@ -23,7 +23,7 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.vault.entrypoints: websecure
-      traefik.http.routers.vault.middlewares: https-local@file
+      traefik.http.routers.vault.middlewares: localaccess@file
       traefik.http.routers.vault.rule: Host(`vault.${MYDOMAIN}`)
       traefik.http.services.vault.loadbalancer.server.port: 80
       homepage.group: Tools


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
	- Updated Traefik middleware configurations across multiple services from `https-local@file` to `localaccess@file`
	- Removed explicit `websecure` entry points for several services
	- Modified authentication middleware for some services to use SSO approach

- **Infrastructure**
	- Upgraded Traefik image from v3.3 to v3.3.1
	- Updated dynamic configuration for routing and middleware handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->