### PR TITLE
Setup a new host, extend setup documentation

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -27,6 +27,8 @@ https://www.ansible.com/
 3. Add hosts to `inventory/inventory.yaml`
 4. Assign roles to hosts in `playbooks/`
 5. Run `apply-<playbook>.sh` to execute a playbook
+   - If you use a non-root user and `sudo` requires a password (indicated by the "Missing sudo password" error message), use `apply-<playbook>.sh --ask-become-pass` and specify the password when requested ("BECOME password" message)
+   - The playbook will set up passwordless `sudo`, so next time the `--ask-become-pass` parameter will not be required
 6. When the administrative user is already created, use that user in the inventory instead of `root` (`ansible_user: <adminuser>`). This is more secure and also required by Homebrew.
 
 ## Bootstrapping hosts with authentication

--- a/ansible/bootstrap-ansible.sh
+++ b/ansible/bootstrap-ansible.sh
@@ -20,7 +20,8 @@ install_ansible_on_ubuntu() {
   add-apt-repository --yes --update ppa:ansible/ansible
   apt-get install --yes --no-install-recommends ansible python3-pip
 
-  pip install passlib ansible-lint --break-system-packages
+  # "--ignore-installed" is added to fix error "Cannot uninstall PyYAML 6.0.1 ... The package was installed by debian."
+  pip install passlib ansible-lint --ignore-installed --break-system-packages
   ansible-galaxy install -r "${ANSIBLE_DIR}/requirements.yml"
 }
 

--- a/ansible/inventory/inventory.yaml
+++ b/ansible/inventory/inventory.yaml
@@ -8,6 +8,8 @@ debian:
     proxmox:
       ansible_host: 192.168.1.50
     nas: {}
+    hive:
+      ansible_host: 192.168.1.243
     nest:
       install_storage_packages: true
 

--- a/ansible/playbooks/homelab.yaml
+++ b/ansible/playbooks/homelab.yaml
@@ -10,14 +10,13 @@
   hosts:
     - nas
     - nest
-    - nest2
+    - hive
   roles:
     - role: debian_docker_host
 
 - name: Setup Samba client + developer tools
   hosts:
     - nest
-    - nest2
   roles:
     - role: debian_samba_client
     - role: markosamuli.linuxbrew

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -122,6 +122,7 @@ After setting up the VM, configure the following on the router:
   - HTTPS - Port 443 TCP & UDP
   - WireGuard - Port 51820 UDP
 - Configure the local DNS service to resolve your domain name to the main Docker host. This is to provide uninterrupted DNS name resolution of the local services in case of the internet access fails.
+  - In AdGuard Home: Filters -> DNS Rewrites -> Add <hostname> AND *.<hostname>
 
 Note: Query and refresh IP configuration on Windows:
 ```sh

--- a/proxmox/ubuntu.md
+++ b/proxmox/ubuntu.md
@@ -30,7 +30,7 @@ In addition to the previous, this script also configures the installer for unatt
 ```
 ssh root@proxmox "bash -s" -- < create-ubuntu-server-vm.sh
 ```
-- Start the VM and confirm the installation
+- Start the VM and confirm the installation ("Continue with autoinstall?" prompt)
 
 **Details:**
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated Ansible README with setup steps for non-root users and sudo configuration.
	- Added new host `hive` to Ansible inventory.
	- Updated Ansible playbook to target `hive` instead of `nest2`.
	- Enhanced Ubuntu Proxmox installation instructions with clarification on autoinstall prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->