### PR TITLE
Replace Traefik Crowdsec bouncer container with plugin, install iptables bouncer

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,9 +13,8 @@ fact_caching_timeout = 43200
 hash_behaviour = merge
 forks = 32
 
-# https://docs.ansible.com/ansible/latest/plugins/callback.html
-# https://docs.ansible.com/ansible/latest/collections/index_callback.html
-stdout_callback = yaml
+# https://docs.ansible.com/ansible/latest/collections/ansible/builtin/default_callback.html
+callback_result_format = yaml
 
 [ssh_connection]
 pipelining = true

--- a/ansible/inventory/group_vars/debian/vars.yaml
+++ b/ansible/inventory/group_vars/debian/vars.yaml
@@ -9,6 +9,8 @@ ssh_key_file: "~/.ssh/id_ed25519.pub"
 
 configure_hosts_file: true
 
+install_crowdsec_bouncer: false
+
 linuxbrew_use_installer: true
 linuxbrew_init_shell: true
 

--- a/ansible/inventory/inventory.yaml
+++ b/ansible/inventory/inventory.yaml
@@ -5,13 +5,18 @@ debian:
     ansible_conection: ssh
     ansible_user: buba
   hosts:
+    nas: {}
     proxmox:
       ansible_host: 192.168.1.50
-    nas: {}
     hive:
       ansible_host: 192.168.1.243
     nest:
       install_storage_packages: true
+
+      # Crowdsec - configure docker/security/crowdsec.yaml and
+      #   set 'crowdsec_local_api_key' in group_vars/debian/secret.yaml
+      install_crowdsec_bouncer: true
+      crowdsec_local_api_url: http://127.0.0.1:7080/
 
     # Cloud. Excluded in apply-homelab.sh
     azure-vm:

--- a/ansible/roles/debian_base/handlers/main.yaml
+++ b/ansible/roles/debian_base/handlers/main.yaml
@@ -3,3 +3,8 @@
   ansible.builtin.service:
     name: systemd-resolved
     state: restarted
+
+- name: Restart service crowdsec-firewall-bouncer
+  ansible.builtin.service:
+    name: crowdsec-firewall-bouncer
+    state: restarted

--- a/ansible/roles/debian_base/tasks/45-crowdsec.yaml
+++ b/ansible/roles/debian_base/tasks/45-crowdsec.yaml
@@ -1,0 +1,49 @@
+# Based on:
+# https://packagecloud.io/crowdsec/crowdsec/install#manual-deb
+# https://docs.crowdsec.net/u/bouncers/firewall/
+# https://github.com/papanito/ansible-role-crowdsec/
+#
+# Configuration file: /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+# Logs: /var/log/crowdsec-firewall-bouncer.log
+---
+- name: Add crowdsec apt-key
+  ansible.builtin.apt_key:
+    url: https://packagecloud.io/crowdsec/crowdsec/gpgkey
+    state: present
+
+- name: Add crowdsec apt repository
+  ansible.builtin.apt_repository:
+    repo: deb https://packagecloud.io/crowdsec/crowdsec/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main
+    state: present
+    filename: crowdsec
+    update_cache: true
+
+- name: Install crowdsec iptables bouncer
+  ansible.builtin.apt:
+    name: crowdsec-firewall-bouncer-iptables
+    state: present
+
+- name: Set crowdsec api_url for iptables bouncer
+  ansible.builtin.lineinfile:
+    path: /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+    regexp: "^api_url:"
+    line: "api_url: {{ crowdsec_local_api_url }}"
+  when: crowdsec_local_api_url|default('') != ''
+  notify: Restart service crowdsec-firewall-bouncer
+
+- name: Set crowdsec api_key for iptables bouncer
+  ansible.builtin.lineinfile:
+    path: /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+    regexp: "^api_key:"
+    line: "api_key: {{ crowdsec_local_api_key }}"
+  when: crowdsec_local_api_key|default('') != ''
+  notify: Restart service crowdsec-firewall-bouncer
+
+- name: Enable service crowdsec-firewall-bouncer
+  ansible.builtin.service:
+    name: crowdsec-firewall-bouncer
+    enabled: true
+    state: started
+  when:
+    - crowdsec_local_api_url|default('') != ''
+    - crowdsec_local_api_key|default('') != ''

--- a/ansible/roles/debian_base/tasks/main.yaml
+++ b/ansible/roles/debian_base/tasks/main.yaml
@@ -11,6 +11,11 @@
   ansible.builtin.import_tasks: 40-network.yaml
   become: true
 
+- name: Install Crowdsec iptables bouncer
+  when: install_crowdsec_bouncer|default(false)|bool
+  ansible.builtin.import_tasks: 45-crowdsec.yaml
+  become: true
+
 - name: Configure admin user
   ansible.builtin.import_tasks: 50-user.yaml
   become: true

--- a/docker/security/crowdsec.yaml
+++ b/docker/security/crowdsec.yaml
@@ -27,6 +27,7 @@ services:
       - 8080
     environment:
       PGID: "1000"
+      # https://app.crowdsec.net/hub/collections
       COLLECTIONS: "crowdsecurity/traefik crowdsecurity/http-cve Dominic-Wagner/vaultwarden LePresidente/jellyfin crowdsecurity/endlessh"
     volumes:
       - ./crowdsec/acquis.yaml:/etc/crowdsec/acquis.yaml
@@ -40,6 +41,8 @@ services:
       - ${DOCKER_VOLUMES}/vaultwarden/vaultwarden.log:/var/log/vaultwarden.log:ro
       - ${DOCKER_VOLUMES}/jellyfin/log:/var/log/jellyfin:ro
       - ${DOCKER_VOLUMES}/endlessh/logs/endlessh:/var/log/endlessh:ro
+    networks:
+      - proxy
     labels:
       homepage.group: Security
       homepage.name: Crowdsec
@@ -47,22 +50,6 @@ services:
       homepage.href: https://app.crowdsec.net/
       homepage.description: "Crowdsec Security Engine"
 
-  # TODO Deprecated! Last image update: october 2022
-  # Replace with Crowdsec Bouncer Traefik plugin
-  # https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin
-  crowdsec-traefik-bouncer:
-    image: fbonalair/traefik-crowdsec-bouncer:0.5.0
-    container_name: bouncer-traefik
-    restart: unless-stopped
-    environment:
-      # Generate key within the crowdsec container: cscli bouncers add traefik-bouncer
-      CROWDSEC_BOUNCER_API_KEY: ${CROWDSEC_BOUNCER_API_KEY}
-      CROWDSEC_AGENT_HOST: crowdsec:8080
-      GIN_MODE: release
-    depends_on:
-      - crowdsec
-
 networks:
-  default:
+  proxy:
     external: true
-    name: proxy

--- a/docker/security/crowdsec.yaml
+++ b/docker/security/crowdsec.yaml
@@ -5,7 +5,8 @@
 # 📜 Source: https://github.com/crowdsecurity/example-docker-compose  
 # Tutorial: https://docs.ibracorp.io/crowdsec/  
 #
-# Register to dashboard, subscribe to blocklists: https://app.crowdsec.net/
+# Register to dashboard, subscribe to blocklists: https://app.crowdsec.net/  
+# Configure iptables bouncer with Ansible: `ansible/roles/debian_base/tasks/45-crowdsec.yaml`
 #
 # Useful commands - execute within the container like `docker exec crowdsec <command>`:
 # - `cscli collections list`
@@ -13,9 +14,6 @@
 # - `cscli decisions list`
 # - `cscli alerts list`
 # - `cscli metrics`
-#
-# TODO Install firewall Bouncer:
-#   https://www.smarthomebeginner.com/crowdsec-docker-compose-1-fw-bouncer/
 ---
 name: crowdsec
 services:
@@ -23,8 +21,9 @@ services:
     image: crowdsecurity/crowdsec:v1.6.5
     container_name: crowdsec
     restart: unless-stopped
-    expose:
-      - 8080
+    ports:
+      # Host port 7080 for API access
+      - 7080:8080/tcp
     environment:
       PGID: "1000"
       # https://app.crowdsec.net/hub/collections
@@ -44,6 +43,10 @@ services:
     networks:
       - proxy
     labels:
+      traefik.enable: true
+      traefik.http.routers.crowdsec.rule: Host(`crowdsec.${MYDOMAIN}`)
+      traefik.http.routers.crowdsec.middlewares: localaccess@file
+      traefik.http.services.crowdsec.loadbalancer.server.port: 8080
       homepage.group: Security
       homepage.name: Crowdsec
       homepage.icon: crowdsec.png

--- a/docker/security/traefik.yaml
+++ b/docker/security/traefik.yaml
@@ -16,6 +16,8 @@ services:
       MYDOMAIN: ${MYDOMAIN}
       MAIN_NODE_IP: ${MAIN_NODE_IP}
       CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
+      # Generate key within the crowdsec container: cscli bouncers add traefik-bouncer
+      CROWDSEC_BOUNCER_API_KEY: ${CROWDSEC_BOUNCER_API_KEY}
       # Used in static configuration (traefik.yml)
       TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_MAIN: "${MYDOMAIN}"
       TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_SANS: "*.${MYDOMAIN}"

--- a/docker/security/traefik.yaml
+++ b/docker/security/traefik.yaml
@@ -53,7 +53,7 @@ services:
   logrotate:
     build:
       dockerfile_inline: |
-        FROM alpine:3.20
+        FROM alpine:3.21
         RUN apk add --no-cache logrotate
         COPY traefik/logrotate.conf /etc/logrotate.conf
         RUN chmod 644 /etc/logrotate.conf

--- a/docker/security/traefik/dynamic/middlewares.yml
+++ b/docker/security/traefik/dynamic/middlewares.yml
@@ -49,9 +49,14 @@ http:
         trustForwardHeader: true
 
     crowdsec-bouncer:
-      forwardAuth:
-        address: http://bouncer-traefik:8080/api/v1/forwardAuth
-        trustForwardHeader: true
+      plugin:
+        # Crowdsec Bouncer Traefik Plugin
+        # https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin
+        crowdsec-bouncer-traefik-plugin:
+          Enabled: "true"
+          CrowdsecLapiKey: '{{env "CROWDSEC_BOUNCER_API_KEY"}}'
+          CrowdsecLapiHost: crowdsec:8080
+          CrowdsecMode: "live"
 
     security-headers:
       headers:

--- a/docker/security/traefik/traefik.yml
+++ b/docker/security/traefik/traefik.yml
@@ -91,3 +91,11 @@ certificatesResolvers:
         resolvers:
           - "1.1.1.1:53" # Specifies a list of DNS resolvers to use for the DNS queries
           - "8.8.8.8:53"
+
+experimental:
+  plugins:
+    # Crowdsec Bouncer Traefik Plugin
+    # https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin
+    crowdsec-bouncer-traefik-plugin:
+      moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+      version: "v1.4.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable for managing collections in the Crowdsec service.
  - Enabled improved network connectivity by connecting the Crowdsec service to the proxy network.
  - Added support for a new Crowdsec bouncer API key in the Traefik service configuration.
  - Integrated a plugin-based approach for authentication middleware, offering dynamic key management and a live operational mode.
  - Rolled out experimental plugin support with clear versioning details.
  - Added new configuration options for managing the installation of the CrowdSec bouncer.
  - Introduced a new task for installing and configuring the CrowdSec firewall bouncer on Debian-based systems.
  - Added a new task to conditionally install the Crowdsec iptables bouncer.

- **Chores**
  - Removed deprecated bouncer integration.
  - Updated underlying container base images for improved performance.
  - Restored the `nas` host entry in the inventory configuration.
  - Added a new handler for restarting the Crowdsec firewall bouncer service.
  - Updated Ansible configuration to align with new standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->