### PR TITLE
Setup redundant DNS with AdGuard Home Sync

### DIFF
--- a/config-example/docker/.env
+++ b/config-example/docker/.env
@@ -13,6 +13,9 @@ MYDOMAIN=example.com
 MAIN_NODE=nest
 MAIN_NODE_IP=192.168.1.20
 
+SECOND_NODE=hive
+SECOND_NODE_IP=192.168.1.243
+
 # Local accounts
 
 ADMIN_USER=admin

--- a/config-example/docker/myhost/.env
+++ b/config-example/docker/myhost/.env
@@ -25,6 +25,10 @@ STORAGE_MEDIA=${STORAGE_NAS}/media
 STORAGE_FAMILYMEDIA=${STORAGE_NAS}/family-media
 STORAGE_BACKUP_ON_NAS=${STORAGE_NAS}/backup
 
+### Hosts
+
+LOCAL_NODE_IP=192.168.1.20
+
 ### For Homepage
 
 LOCATION_CITY=Greenwich
@@ -32,6 +36,9 @@ LOCATION_LATITUDE=51.48
 LOCATION_LONGITUDE=0.00
 
 ### Local accounts
+
+ADGUARDHOME_USERNAME="use-some-very-secure-value-here"
+ADGUARDHOME_PASSWORD="use-some-very-secure-value-here"
 
 KOPIA_B2_REPOSITORY_PASSWORD="use-some-very-secure-value-here"
 KOPIA_NAS_REPOSITORY_PASSWORD="use-some-very-secure-value-here"
@@ -57,7 +64,7 @@ CROWDSEC_BOUNCER_API_KEY="use-some-very-secure-value-here"
 # Use a local account that has at least read privileges. Local account can be created on the Legacy Interface.
 # To temporally switch to the old interface: Settings -> System -> Legacy Interface -> Enable
 # Then create the user on Settings -> Admins
-UNIFI_LOCAL_VIEWONLY_USERNAME="viewonly"
+UNIFI_LOCAL_VIEWONLY_USERNAME="use-some-very-secure-value-here"
 UNIFI_LOCAL_VIEWONLY_PASSWORD="use-some-very-secure-value-here"
 
 # Generate a secure random key (min 32 chars) using: `openssl rand -base64 32`

--- a/config-example/docker/myhost/services.yaml
+++ b/config-example/docker/myhost/services.yaml
@@ -26,6 +26,8 @@ services:
         state: up
       - name: adguardhome
         state: up
+      - name: adguardhome-sync
+        state: up
       - name: unifi-controller
         state: up
       - name: ddclient

--- a/docker/infra/adguardhome-sync.yaml
+++ b/docker/infra/adguardhome-sync.yaml
@@ -1,0 +1,47 @@
+# Synchronize AdGuard Home config to replicas
+#
+# Prerequisites: Both the origin instance and replica(s) must be initially set up with AdguardHome via the AdguardHome installation wizard.
+#
+# Note:
+# > While Windows will prioritize the first DNS provider, systemd-based Linux distributions will enact a "parallel probe" of all servers and pick the fastest responder.
+# > The same goes for Android, macOS, and iOS, where all servers are questioned at once, and the fastest to answer is considered correct.
+# See more: https://www.xda-developers.com/two-pi-holes-spare-resources-recommend/
+#
+# Source: https://github.com/bakito/adguardhome-sync
+---
+name: adguardhome-sync
+services:
+  adguardhome-sync:
+    image: ghcr.io/bakito/adguardhome-sync:v0.7.8
+    container_name: adguardhome-sync
+    command: run
+    restart: unless-stopped
+    environment:
+      # Config reference: https://github.com/bakito/adguardhome-sync?tab=readme-ov-file#config-via-environment-variables
+      CRON: "0 */2 * * *"
+      ORIGIN_URL: "http://${MAIN_NODE_IP}:3000"
+      ORIGIN_USERNAME: ${ADGUARDHOME_USERNAME}
+      ORIGIN_PASSWORD: ${ADGUARDHOME_PASSWORD}
+      REPLICA1_URL: "http://${SECOND_NODE_IP}:3000"
+      REPLICA1_USERNAME: ${ADGUARDHOME_USERNAME}
+      REPLICA1_PASSWORD: ${ADGUARDHOME_PASSWORD}
+      API_PORT: 8080
+      API_DARK_MODE: true
+      API_METRICS_ENABLED: true
+      API_METRICS_SCRAPE_INTERVAL: 600s
+      API_METRICS_QUERY_LOG_LIMIT: 10000
+    networks:
+      - proxy
+    labels:
+      traefik.enable: true
+      traefik.http.routers.adguardhome-sync.middlewares: localaccess@file
+      traefik.http.services.adguardhome-sync.loadbalancer.server.port: 8080
+      homepage.group: Tools
+      homepage.name: AdGuard Home sync
+      homepage.icon: adguard-home.png
+      homepage.href: https://adguardhome-sync.${MYDOMAIN}/
+      homepage.description: Synchronize AdGuard Home config to replicas
+
+networks:
+  proxy:
+    external: true

--- a/docker/infra/adguardhome.yaml
+++ b/docker/infra/adguardhome.yaml
@@ -1,6 +1,12 @@
 # AdGuard Home is a network-wide software for blocking ads and tracking. After you set it up, it'll cover all your home devices, and you won't need any client-side software for that
 #
-# To fix "listen tcp4 0.0.0.0:53: bind: address already in use" error on Ubuntu: disable `DNSStubListener` (see Ansible)
+# To fix "listen tcp4 0.0.0.0:53: bind: address already in use" error on Ubuntu: disable `DNSStubListener` (see Ansible).  
+# Follow the AdguardHome installation wizard for first-time configuration. (Note: Firefox may not allow access to the admin interface)
+#
+# Best practice:
+#  1. Configure two instances of AdGuard Home on two separate hardware
+#  2. Setup adguardhome-sync to sync the settings
+#  3. Specify both DNS servers in the router's DHCP settings
 #
 # 🏠 Home: https://adguard.com/en/adguard-home/overview.html  
 # 📦 Image: https://hub.docker.com/r/adguard/adguardhome  
@@ -17,8 +23,8 @@ services:
     ports:
       # Fix for DNS access from containers
       # https://github.com/AdguardTeam/AdGuardHome/discussions/6252
-      - "${MAIN_NODE_IP}:53:53/tcp" # plain DNS
-      - "${MAIN_NODE_IP}:53:53/udp" # plain DNS
+      - "${LOCAL_NODE_IP}:53:53/tcp" # plain DNS
+      - "${LOCAL_NODE_IP}:53:53/udp" # plain DNS
 
       # - 67:67/udp # add if you intend to use AdGuard Home as a DHCP server
       # - 68:68/udp # add if you intend to use AdGuard Home as a DHCP server

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -122,6 +122,7 @@ After setting up the VM, configure the following on the router:
 - To enable external access to selected services: Port forward to the VM (In OpenWrt: Network -> Firewall -> Port Forwards)
   - HTTPS - Port 443 TCP & UDP
   - WireGuard - Port 51820 UDP
+- DHCP settings: set the DNS server address to the IP of your AdGuard Home service (set both instances if you are using AdGuard Home Sync)
 - Configure the local DNS service to resolve your domain name to the main Docker host. This is to provide uninterrupted DNS name resolution of the local services in case of the internet access fails.
   - In AdGuard Home: Filters -> DNS Rewrites -> Add <hostname> AND *.<hostname>
 

--- a/scripts/create-example-env.py
+++ b/scripts/create-example-env.py
@@ -4,6 +4,7 @@ import sys
 
 SENSITIVE_VARS_TO_MASK = [
     'KEY',
+    'USERNAME',
     'PASSWORD',
     'PASSPHRASE',
     'TOKEN',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration and orchestration for an AdGuard Home synchronization service, enabling automated syncing between AdGuard Home instances.
  * Introduced new environment variables for secondary node configuration and local node IP addresses.
  * Added environment variables for AdGuard Home credentials with placeholders for secure values.

* **Improvements**
  * Updated environment variable placeholders for sensitive credentials to encourage secure values.
  * Enhanced masking of sensitive environment variables in example files by including usernames.
  * Expanded documentation and setup instructions for AdGuard Home services, including router DNS configuration and best practices for running multiple instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->