### PR TITLE
Correct stashing in git-rebase-fixup task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,11 +40,10 @@ tasks:
       - pre-commit run --all-files
 
   git-rebase-fixup:
-    desc: Interactively rebase current branch to origin (stash, rebase, pop)
+    desc: Interactively rebase current branch to origin/main (stash, rebase, pop)
+    aliases: [rebase]
     cmds:
-      - git stash
-      - GIT_SEQUENCE_EDITOR=scripts/git-rebase-fixup.py git rebase -i origin/$(git branch --show-current)
-      - git stash pop
+      - scripts/git-rebase-to-main.sh
 
   build:
     desc: Run all linting and build tasks

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,5 @@
 # Scripts
 
-Own scripts:
-- git-rebase-fixup.py
-- jellyfin-rescan.sh
-
 Third-party scripts:
 - git-filter-repo.py
     - Quickly rewrite git repository history (filter-branch replacement)

--- a/scripts/git-rebase-to-main.sh
+++ b/scripts/git-rebase-to-main.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 BASE_REF="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo 'origin/main')"
 STASH_NAME="Automatic-stash-before-rebasing-$(date +%s)"
 
@@ -12,7 +11,7 @@ else
 fi
 
 # Would be possible to use "--autostash", but "--include-untracked" is not supported
-GIT_SEQUENCE_EDITOR="${SCRIPT_DIR}/git-reorder-fixup.py" git rebase --interactive "${BASE_REF}"
+git rebase --interactive --autosquash "${BASE_REF}"
 
 # Not possible to reference stash by name, so the first stash will be popped if the name matches
 if [ "$STASH_SUCCEEDED" = true ] && git stash list --format=%gs | head -1 | grep -q "${STASH_NAME}"; then

--- a/scripts/git-rebase-to-main.sh
+++ b/scripts/git-rebase-to-main.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+BASE_REF="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo 'origin/main')"
+STASH_NAME="Automatic-stash-before-rebasing-$(date +%s)"
+
+if git stash push --include-untracked -m "${STASH_NAME}"; then
+    STASH_SUCCEEDED=true
+else
+    STASH_SUCCEEDED=false
+fi
+
+# Would be possible to use "--autostash", but "--include-untracked" is not supported
+GIT_SEQUENCE_EDITOR="${SCRIPT_DIR}/git-reorder-fixup.py" git rebase --interactive "${BASE_REF}"
+
+# Not possible to reference stash by name, so the first stash will be popped if the name matches
+if [ "$STASH_SUCCEEDED" = true ] && git stash list --format=%gs | head -1 | grep -q "${STASH_NAME}"; then
+    git stash pop --quiet
+fi

--- a/scripts/git-reorder-fixup.py
+++ b/scripts/git-reorder-fixup.py
@@ -2,8 +2,8 @@
 
 # This Python script reorders git commits containing the "[FIXUP]" text to be right after their counterpart commit in a given file, modifies the command to "fixup" for these lines, and then opens the modified file in the nano text editor for review or further changes.
 
-# GIT_SEQUENCE_EDITOR=~/repos/infra/scripts/git-rebase-fixup.py git rebase -i abcdef1234
-# alias rebase-fixup="GIT_SEQUENCE_EDITOR=~/repos/infra/scripts/git-rebase-fixup.py git rebase -i"
+# GIT_SEQUENCE_EDITOR=~/repos/infra/scripts/git-reorder-fixup.py git rebase -i abcdef1234
+# alias rebase-fixup="GIT_SEQUENCE_EDITOR=~/repos/infra/scripts/git-reorder-fixup.py git rebase -i"
 # git config --global sequence.editor "code --wait"
 
 import sys


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default interactive rebase now targets the repository main/upstream branch.
  * Added a convenient "rebase" alias and reduced console noise.
  * Consolidated the multi-step stash/rebase/pop workflow into a single scripted task for reliability.
  * Safer handling of local changes: stashes (including untracked) with timestamped restore when appropriate.

* **Documentation**
  * Removed the "Own scripts" section from the scripts README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->