### PR TITLE
Isolate networks of sensitive services

### DIFF
--- a/docker/backup/kopia-b2.yaml
+++ b/docker/backup/kopia-b2.yaml
@@ -52,10 +52,11 @@ services:
       - ${STORAGE_MEDIA}:/sources/nas/media:ro
 
     networks:
-      - proxy
+      - backup-kopia
 
     labels:
       traefik.enable: true
+      traefik.docker.network: backup-kopia
       traefik.http.routers.kopia-b2.middlewares: localaccess-sso@file
       traefik.http.services.kopia-b2.loadbalancer.server.port: 80
       homepage.group: Storage
@@ -65,5 +66,5 @@ services:
       homepage.description: "[SSO] Backups Using the Cloud Storage You Pick"
 
 networks:
-  proxy:
+  backup-kopia:
     external: true

--- a/docker/backup/kopia-nas.yaml
+++ b/docker/backup/kopia-nas.yaml
@@ -50,10 +50,11 @@ services:
       - ${STORAGE_BACKUP_ON_NAS}/kopia:/backup-on-nas
 
     networks:
-      - proxy
+      - backup-kopia
 
     labels:
       traefik.enable: true
+      traefik.docker.network: backup-kopia
       traefik.http.routers.kopia-nas.middlewares: localaccess-sso@file
       traefik.http.services.kopia-nas.loadbalancer.server.port: 80
       homepage.group: Storage
@@ -63,5 +64,5 @@ services:
       homepage.description: "[SSO] Backups Using the Cloud Storage You Pick"
 
 networks:
-  proxy:
+  backup-kopia:
     external: true

--- a/docker/dev/code-server.yaml
+++ b/docker/dev/code-server.yaml
@@ -30,9 +30,10 @@ services:
       - ${ADMIN_HOME}/repos:/config/repos
       - ${ADMIN_HOME}/.ssh:/config/.ssh
     networks:
-      - proxy
+      - dev-code-server
     labels:
       traefik.enable: true
+      traefik.docker.network: dev-code-server
       traefik.http.routers.code.middlewares: localaccess-sso@file
       traefik.http.routers.code.rule: Host(`code.${MYDOMAIN}`)
       traefik.http.services.code.loadbalancer.server.port: 8443
@@ -43,5 +44,5 @@ services:
       homepage.description: "[SSO] Visual Studio Code"
 
 networks:
-  proxy:
+  dev-code-server:
     external: true

--- a/docker/security/authelia.yaml
+++ b/docker/security/authelia.yaml
@@ -42,12 +42,13 @@ services:
     expose:
       - 9091
     networks:
-      - proxy
+      - security-authelia
     depends_on:
       initContainer:
         condition: service_completed_successfully
     labels:
       traefik.enable: true
+      traefik.docker.network: security-authelia
       traefik.http.routers.authelia.rule: Host(`auth.${MYDOMAIN}`)
       traefik.http.routers.authelia.middlewares: localaccess@file
       traefik.http.services.authelia.loadbalancer.server.port: 9091
@@ -58,5 +59,5 @@ services:
       homepage.description: "[SSO] Open-source authentication and authorization"
 
 networks:
-  proxy:
+  security-authelia:
     external: true

--- a/docker/security/endlessh.yaml
+++ b/docker/security/endlessh.yaml
@@ -33,14 +33,8 @@ services:
     ports:
       - 2222:2222
       # Prometheus metrics port: 2112
-    networks:
-      - proxy
     labels:
       homepage.group: Security
       homepage.name: Endlessh
       homepage.icon: terminal.png
       homepage.description: "SSH tarpit (port 2222)"
-
-networks:
-  proxy:
-    external: true

--- a/docker/security/traefik.yaml
+++ b/docker/security/traefik.yaml
@@ -34,6 +34,11 @@ services:
       - 443:443/udp # HTTP/3 - QUIC
     networks:
       - proxy
+      - security-authelia
+      - security-wg-easy
+      - dev-code-server
+      - tools-vaultwarden
+      - backup-kopia
     extra_hosts:
       - host.docker.internal:host-gateway
     labels:
@@ -66,4 +71,14 @@ services:
 
 networks:
   proxy:
+    external: true
+  security-authelia:
+    external: true
+  security-wg-easy:
+    external: true
+  dev-code-server:
+    external: true
+  tools-vaultwarden:
+    external: true
+  backup-kopia:
     external: true

--- a/docker/security/traefik/traefik.yml
+++ b/docker/security/traefik/traefik.yml
@@ -29,7 +29,7 @@ providers:
   # Docker provider for connecting all apps that are inside of the docker network
   docker:
     watch: true
-    network: proxy
+    network: proxy  # Can be overridden on a per-container basis with the traefik.docker.network label
     defaultRule: 'Host(`{{ index .Labels "com.docker.compose.service"}}.{{env "MYDOMAIN"}}`)'  # Default host rule: containername.domain.tld
     exposedByDefault: false  # Do not expose containers to the outside world unless explicitly configured
 

--- a/docker/security/wg-easy.yaml
+++ b/docker/security/wg-easy.yaml
@@ -32,9 +32,10 @@ services:
     volumes:
       - ${DOCKER_VOLUMES}/wg-easy:/etc/wireguard
     networks:
-      - proxy
+      - security-wg-easy
     labels:
       traefik.enable: true
+      traefik.docker.network: security-wg-easy
       traefik.http.routers.wireguard.rule: Host(`vpn.${MYDOMAIN}`)
       traefik.http.routers.wireguard.middlewares: localaccess-sso@file
       traefik.http.services.wireguard.loadbalancer.server.port: 51821
@@ -45,5 +46,5 @@ services:
       homepage.description: "[SSO] VPN Service"
 
 networks:
-  proxy:
+  security-wg-easy:
     external: true

--- a/docker/tools/vaultwarden.yaml
+++ b/docker/tools/vaultwarden.yaml
@@ -19,9 +19,10 @@ services:
     volumes:
       - ${DOCKER_VOLUMES}/vaultwarden:/data
     networks:
-      - proxy
+      - tools-vaultwarden
     labels:
       traefik.enable: true
+      traefik.docker.network: tools-vaultwarden
       traefik.http.routers.vault.middlewares: localaccess@file
       traefik.http.routers.vault.rule: Host(`vault.${MYDOMAIN}`)
       traefik.http.services.vault.loadbalancer.server.port: 80
@@ -32,5 +33,5 @@ services:
       homepage.description: Password Manager
 
 networks:
-  proxy:
+  tools-vaultwarden:
     external: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically detects and creates required external Docker networks before running compose commands, reducing setup errors.

- Improvements
  - Services moved to dedicated, isolated networks (backup, security, tools, dev) for better isolation and reliability.
  - Traefik now attaches to and routes across these networks so routing uses the correct network bindings.
  - Removed unnecessary shared proxy attachments from services that no longer require them.

- Documentation
  - Added guidance on using isolated networks and overriding Traefik’s Docker network.

- Chores
  - Standardized compose files to declare external networks explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->