### PR TITLE
Fix WireGuard after updating to Ubuntu 26.04 LTS

### DIFF
--- a/docker/security/wg-easy/wg-easy.yaml
+++ b/docker/security/wg-easy/wg-easy.yaml
@@ -30,8 +30,10 @@ services:
       WG_ALLOWED_IPS: "192.168.0.0/16" # Allowed IPs clients will use
     ports:
       - 51820:51820/udp # VPN
+    # kics-scan ignore-block - WireGuard requires read-only access to kernel modules to load the wireguard module
     volumes:
       - ${DOCKER_VOLUMES}/wg-easy:/etc/wireguard
+      - /lib/modules:/lib/modules:ro
     networks:
       - security-wg-easy
     labels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->