### PR TITLE
Add setup script for creating a NetworkManager bridge for libvirt VMs, add nat/bridge selection

### DIFF
--- a/vm/libvirt/create-ubuntu-cloud-vm.sh
+++ b/vm/libvirt/create-ubuntu-cloud-vm.sh
@@ -12,6 +12,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib-common.sh"
 
 # === User configuration ===
 
+# Network type: "nat" uses libvirt's default NAT network; "bridge" attaches directly
+# to the LAN bridge (requires setup-bridge.sh to have been run first, bridge name below).
+readonly NETWORK_TYPE="nat"  # "nat" | "bridge"
+readonly BRIDGE_NAME="br0"
+
 # renovate: datasource=endoflife depName=ubuntu
 readonly UBUNTU_VERSION="26.04"
 
@@ -89,6 +94,13 @@ create_vm() {
         osinfo_arg="detect=on,require=off"
     fi
 
+    local network_arg
+    if [[ "${NETWORK_TYPE}" == "bridge" ]]; then
+        network_arg="bridge=${BRIDGE_NAME},model=virtio"
+    else
+        network_arg="network=default,model=virtio"
+    fi
+
     virt-install \
         --name "${VMNAME}" \
         --memory "${MEMORY_SIZE}" \
@@ -96,7 +108,7 @@ create_vm() {
         --disk "path=${VM_DISK},format=qcow2,bus=virtio" \
         --import \
         --osinfo "${osinfo_arg}" \
-        --network "network=default,model=virtio" \
+        --network "${network_arg}" \
         --graphics none \
         --noautoconsole \
         --cloud-init "user-data=${INIT_DIR}/user-data,meta-data=${INIT_DIR}/meta-data,disable=on"
@@ -130,6 +142,7 @@ for cmd in wget qemu-img virt-install virsh; do
 done
 
 parse_download_only_arg "$@"
+
 download_cloud_image
 
 if [ "$DOWNLOAD_ONLY" = true ]; then

--- a/vm/libvirt/setup-bridge.sh
+++ b/vm/libvirt/setup-bridge.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a NetworkManager bridge over a physical NIC so libvirt VMs can get
+# IPs directly from the LAN router. Idempotent: safe to run multiple times.
+#
+# Usage: sudo ./setup-bridge.sh [BRIDGE_NAME [PHYSICAL_IF]]
+# Defaults: bridge=br0, physical interface=eno1
+#
+# Note: after running this, the desktop network manager applet (taskbar "Networks"
+# popup) will show "No available connections". This is cosmetic — the physical NIC
+# becomes a bridge slave which NM applets don't display. The network works normally.
+
+BRIDGE_NAME="${1:-br0}"
+PHYSICAL_IF="${2:-eno1}"
+SLAVE_CON="${BRIDGE_NAME}-slave-${PHYSICAL_IF}"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root (use sudo)" >&2
+    exit 1
+fi
+
+command -v nmcli >/dev/null || { echo "Missing required tool: nmcli" >&2; exit 1; }
+
+conn_exists() { nmcli connection show "$1" &>/dev/null; }
+
+# If the bridge interface is already up and owns the physical NIC, nothing to do
+if ip link show "${BRIDGE_NAME}" &>/dev/null && \
+   ip link show "${PHYSICAL_IF}" 2>/dev/null | grep -q "master ${BRIDGE_NAME}"; then
+    echo "Bridge ${BRIDGE_NAME} is already active with ${PHYSICAL_IF} enslaved. Nothing to do."
+    exit 0
+fi
+
+echo "Setting up bridge ${BRIDGE_NAME} over ${PHYSICAL_IF}..."
+
+if ! conn_exists "${BRIDGE_NAME}"; then
+    echo "Creating bridge connection ${BRIDGE_NAME}..."
+    # Clone the physical NIC's MAC so the router assigns the same IP as before
+    phys_mac=$(cat "/sys/class/net/${PHYSICAL_IF}/address")
+    nmcli connection add type bridge ifname "${BRIDGE_NAME}" con-name "${BRIDGE_NAME}" \
+        802-3-ethernet.cloned-mac-address "${phys_mac}"
+fi
+
+if ! conn_exists "${SLAVE_CON}"; then
+    echo "Creating slave connection ${SLAVE_CON}..."
+    nmcli connection add type bridge-slave ifname "${PHYSICAL_IF}" master "${BRIDGE_NAME}" con-name "${SLAVE_CON}"
+fi
+
+# Find the active connection on the physical NIC (if any) and bring it down
+ACTIVE_CON=$(nmcli -g NAME,DEVICE connection show --active | grep ":${PHYSICAL_IF}$" | cut -d: -f1 || true)
+if [[ -n "${ACTIVE_CON}" && "${ACTIVE_CON}" != "${SLAVE_CON}" ]]; then
+    echo "Bringing down existing connection '${ACTIVE_CON}' on ${PHYSICAL_IF}..."
+    nmcli connection down "${ACTIVE_CON}"
+fi
+
+echo "Activating bridge (brief connectivity drop expected)..."
+nmcli connection up "${SLAVE_CON}"
+nmcli connection up "${BRIDGE_NAME}"
+
+echo ""
+echo "Bridge ${BRIDGE_NAME} is up:"
+ip addr show "${BRIDGE_NAME}" | grep -E "inet |state"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing the VM network mode when creating Ubuntu cloud VMs, including NAT or bridged networking.
  * Added a new setup script to create and manage a network bridge for VM networking.

* **Bug Fixes**
  * Improved VM network configuration so it no longer relies on a single hardcoded network setup.
  * Made bridge setup safe to run multiple times without duplicating existing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->